### PR TITLE
Option to generate a rectangular array layout

### DIFF
--- a/changelog_interferometry.txt
+++ b/changelog_interferometry.txt
@@ -1,3 +1,22 @@
+From 4434d67(santoshmh-master):
+==============================
+
+In prisim/interferometry.py,
+
+(*) Add a new subroutine "rect_generator" to generate a 
+rectangular array layout
+
+In scripts/run_prisim.py,
+
+(*) Add an option "HIRAX-1024" in the IF loop checking 
+the keyword array_layout.
+
+In prisim/examples/simparms/defaultparms.yaml,
+
+(*) Add "HIRAX-1024" in the list of accepted default values 
+for 'layout' under 'array' (Antenna Layout)
+(*) Add latitude and longitude for HIRAX
+
 From 2ba94de (bl-gradient):
 ==========================
 

--- a/prisim/examples/simparms/defaultparms.yaml
+++ b/prisim/examples/simparms/defaultparms.yaml
@@ -60,6 +60,7 @@ telescope:
                                 # 34.079 for VLA,
                                 # 19.0965 for GMRT
                                 # -26.82472208 for SKA low
+                                # -25.887222 for HIRAX
 
     longitude       : +21.4278
                                 # Longitude of observatory (in degrees)
@@ -69,6 +70,7 @@ telescope:
                                 # +21.4278 for PAPER and HERA,
                                 # +74.0497 for GMRT,
                                 # +116.7644482 for SKA-Low
+                                # +27.684722 for HIRAX
 
     A_eff           : 154
                                 # Effective area of antenna element
@@ -117,7 +119,7 @@ array   :                       # Parameters 'file' and 'layout'
                                 # 'HERA-7', 'HERA-19', 'HERA-37',
                                 # 'HERA-61', 'HERA-91', 'HERA-127',
                                 # 'HERA-169', 'HERA-217', 'HERA-271',
-                                # 'HERA-331', 'CIRC', or null
+                                # 'HERA-331', 'HIRAX-1024','CIRC', or null
 
     file            : null
                                 # File containing antenna locations

--- a/scripts/run_prisim.py
+++ b/scripts/run_prisim.py
@@ -545,7 +545,7 @@ if antenna_file is not None:
 
     ant_locs = NP.hstack((east.reshape(-1,1), north.reshape(-1,1), elev.reshape(-1,1)))
 else:
-    if array_layout not in ['MWA-128T', 'HERA-7', 'HERA-19', 'HERA-37', 'HERA-61', 'HERA-91', 'HERA-127', 'HERA-169', 'HERA-217', 'HERA-271', 'HERA-331', 'CIRC']:
+    if array_layout not in ['MWA-128T', 'HERA-7', 'HERA-19', 'HERA-37', 'HERA-61', 'HERA-91', 'HERA-127', 'HERA-169', 'HERA-217', 'HERA-271', 'HERA-331','HIRAX-1024','CIRC']:
         raise ValueError('Invalid array layout specified')
 
     if array_layout == 'MWA-128T':
@@ -572,6 +572,8 @@ else:
         ant_locs, ant_label = RI.hexagon_generator(14.6, n_total=271)
     elif array_layout == 'HERA-331':
         ant_locs, ant_label = RI.hexagon_generator(14.6, n_total=331)
+    elif array_layout == 'HIRAX-1024':
+        ant_locs, ant_label = RI.rect_generator(7, n_side=32)
     elif array_layout == 'CIRC':
         ant_locs, ant_label = RI.circular_antenna_array(element_size, minR, maxR=maxR)
     ant_label = NP.asarray(ant_label)


### PR DESCRIPTION
In prisim/interferometry.py,

(*) Add a new subroutine "rect_generator" to generate a
rectangular array layout

In scripts/run_prisim.py,

(*) Add an option "HIRAX-1024" in the IF loop checking
the keyword array_layout.

In prisim/examples/simparms/defaultparms.yaml,

(*) Add "HIRAX-1024" in the list of accepted default values
for 'layout' under 'array' (Antenna Layout)
(*) Add latitude and longitude for HIRAX