### PR TITLE
update in using pyuvdata to write output uvfits files

### DIFF
--- a/prisim/interferometry.py
+++ b/prisim/interferometry.py
@@ -6822,6 +6822,7 @@ class InterferometerArray(object):
             if 'method' not in uvfits_parms:
                 uvfits_parms['method'] = None
             dataobj = InterferometerData(self, ref_point=uvfits_parms['ref_point'])
+            import import ipdb; ipdb.set_trace()
             for datakey in dataobj.infodict['data_array']:
                 dataobj.write(outfile+'-{0}.uvfits'.format(datakey), datatype=datakey, fmt='UVFITS', uvfits_method=uvfits_parms['method'], overwrite=overwrite)
 
@@ -7369,7 +7370,20 @@ class InterferometerData(object):
         attributes_of_uvdata = ['Ntimes', 'Nbls', 'Nblts', 'Nfreqs', 'Npols', 'Nspws', 'data_array', 'vis_units', 'nsample_array', 'flag_array', 'spw_array', 'uvw_array', 'time_array', 'lst_array', 'ant_1_array', 'ant_2_array', 'baseline_array', 'freq_array', 'polarization_array', 'integration_time', 'channel_width', 'object_name', 'telescope_name', 'instrument', 'telescope_location', 'history', 'phase_center_epoch', 'is_phased', 'Nants_data', 'Nants_telescope', 'antenna_names', 'antenna_numbers', 'dateobs', 'phase_center_ra', 'phase_center_dec']
         dataobj = UVData()
         for attrkey in attributes_of_uvdata:
-            if attrkey != 'data_array':
+            if attrkey == 'telescope_location':
+                from pyuvdata import utils
+                loc_array = self.infodict[attrkey]
+                # convert location in lat lon alt degrees to radains
+                loc_array *= NP.pi/180.
+                # convert location in radians to XYZ in ITRF
+                XYZ = utils.XYZ_from_LatLonAlt(*loc_array)
+                setattr(dataobj, attrkey, XYZ)
+            elif attkey == 'phase_type':
+                if self.infodict['is_phased']:
+                    setattr(dataobj, attrkey, 'phased')
+                else:
+                    setattr(dataobj, attrkey, 'drift')
+            elif attrkey != 'data_array':
                 setattr(dataobj, attrkey, self.infodict[attrkey])
             else:
                 if datatype in self.infodict[attrkey]:

--- a/prisim/interferometry.py
+++ b/prisim/interferometry.py
@@ -7377,7 +7377,7 @@ class InterferometerData(object):
                 # convert location in radians to XYZ in ITRF
                 XYZ = utils.XYZ_from_LatLonAlt(*loc_array)
                 setattr(dataobj, attrkey, XYZ)
-            elif attkey == 'phase_type':
+            elif attrkey == 'phase_type':
                 if self.infodict['is_phased']:
                     setattr(dataobj, attrkey, 'phased')
                 else:

--- a/prisim/interferometry.py
+++ b/prisim/interferometry.py
@@ -7366,7 +7366,7 @@ class InterferometerData(object):
         if datatype not in ['noiseless', 'noisy', 'noise']:
             raise ValueError('Invalid input datatype specified')
 
-        attributes_of_uvdata = ['Ntimes', 'Nbls', 'Nblts', 'Nfreqs', 'Npols', 'Nspws', 'data_array', 'vis_units', 'nsample_array', 'flag_array', 'spw_array', 'uvw_array', 'time_array', 'lst_array', 'ant_1_array', 'ant_2_array', 'baseline_array', 'freq_array', 'polarization_array', 'integration_time', 'channel_width', 'object_name', 'telescope_name', 'instrument', 'telescope_location', 'history', 'phase_center_epoch', 'is_phased', 'Nants_data', 'Nants_telescope', 'antenna_names', 'antenna_numbers', 'dateobs', 'phase_center_ra', 'phase_center_dec']
+        attributes_of_uvdata = ['Ntimes', 'Nbls', 'Nblts', 'Nfreqs', 'Npols', 'Nspws', 'data_array', 'vis_units', 'nsample_array', 'flag_array', 'spw_array', 'uvw_array', 'time_array', 'lst_array', 'ant_1_array', 'ant_2_array', 'baseline_array', 'freq_array', 'polarization_array', 'integration_time', 'channel_width', 'object_name', 'telescope_name', 'instrument', 'telescope_location', 'history', 'phase_center_epoch', 'is_phased', 'phase_type', 'Nants_data', 'Nants_telescope', 'antenna_names', 'antenna_numbers', 'dateobs', 'phase_center_ra', 'phase_center_dec']
         dataobj = UVData()
         for attrkey in attributes_of_uvdata:
             if attrkey == 'telescope_location':

--- a/prisim/interferometry.py
+++ b/prisim/interferometry.py
@@ -6822,7 +6822,6 @@ class InterferometerArray(object):
             if 'method' not in uvfits_parms:
                 uvfits_parms['method'] = None
             dataobj = InterferometerData(self, ref_point=uvfits_parms['ref_point'])
-            import import ipdb; ipdb.set_trace()
             for datakey in dataobj.infodict['data_array']:
                 dataobj.write(outfile+'-{0}.uvfits'.format(datakey), datatype=datakey, fmt='UVFITS', uvfits_method=uvfits_parms['method'], overwrite=overwrite)
 

--- a/prisim/interferometry.py
+++ b/prisim/interferometry.py
@@ -6,7 +6,7 @@ import datetime as DT
 import progressbar as PGB
 import os
 import copy
-import astropy 
+import astropy
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy import units
@@ -14,7 +14,7 @@ from astropy.time import Time
 import warnings
 import h5py
 from distutils.version import LooseVersion
-import psutil 
+import psutil
 from astroutils import geometry as GEOM
 from astroutils import gridding_modules as GRD
 from astroutils import constants as CNST
@@ -25,7 +25,7 @@ from astroutils import nonmathops as NMO
 import baseline_delay_horizon as DLY
 import primary_beams as PB
 try:
-    from uvdata import UVData
+    from pyuvdata import UVData
 except ImportError:
     uvdata_module_found = False
 else:
@@ -40,16 +40,16 @@ else:
 ################################################################################
 
 def _astropy_columns(cols, tabtype='BinTableHDU'):
-    
+
     """
     ----------------------------------------------------------------------------
     !!! FOR INTERNAL USE ONLY !!!
-    This internal routine checks for Astropy version and produces the FITS 
+    This internal routine checks for Astropy version and produces the FITS
     columns based on the version
 
     Inputs:
 
-    cols    [list of Astropy FITS columns] These are a list of Astropy FITS 
+    cols    [list of Astropy FITS columns] These are a list of Astropy FITS
             columns
 
     tabtype [string] specifies table type - 'BinTableHDU' (default) for binary
@@ -57,7 +57,7 @@ def _astropy_columns(cols, tabtype='BinTableHDU'):
 
     Outputs:
 
-    columns [Astropy FITS column data] 
+    columns [Astropy FITS column data]
     ----------------------------------------------------------------------------
     """
 
@@ -76,7 +76,7 @@ def _astropy_columns(cols, tabtype='BinTableHDU'):
         columns = fits.ColDefs(cols, tbtype=tabtype)
     elif LooseVersion(astropy.__version__)>=LooseVersion('0.4.2'):
         columns = fits.ColDefs(cols, ascii=use_ascii)
-    return columns    
+    return columns
 
 ################################################################################
 
@@ -89,25 +89,25 @@ def read_gaintable(gainsfile, axes_order=None):
     Input:
 
     gainsfile   [string] Filename including the full path that contains the
-                instrument gains. It must be in HDF5 format. It must contain 
+                instrument gains. It must be in HDF5 format. It must contain
                 the following structure:
-                'antenna-based'     [dictionary] Contains antenna-based 
+                'antenna-based'     [dictionary] Contains antenna-based
                                     instrument gain information. It has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency'. Must be
                                                 specified (no defaults)
-                                    'gains'     [scalar or numpy array] 
-                                                Complex antenna-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex antenna-based
+                                                instrument gains. Must be
                                                 of shape (nax1, nax2, nax3)
                                                 where ax1, ax2 and ax3 are
-                                                specified by the axes 
+                                                specified by the axes
                                                 ordering under key 'ordering'.
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -116,52 +116,52 @@ def read_gaintable(gainsfile, axes_order=None):
                                                 For example, shapes (nax1,1,1),
                                                 (1,1,1), (1,nax2,nax3) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
                                                 'label', 'frequency' and 'time'
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List of antenna labels that
                                                 correspond to the nax along
                                                 the 'label' axis. If the
                                                 nax=1 along the 'label' axis,
                                                 this may be set to None, else
                                                 it must be specified and must
-                                                match the nax. 
-                                    'frequency' [None or list or numpy array] 
+                                                match the nax.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nax=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nax. 
-                                    'time'      [None or list or numpy array] 
+                                                nax=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nax.
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                nax=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
+                                                nax=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
                                                 must match the nax. It must be
-                                                a float and can be in seconds, 
+                                                a float and can be in seconds,
                                                 hours, days, etc.
-                'baseline-based'    [dictionary] Contains baseline-based 
+                'baseline-based'    [dictionary] Contains baseline-based
                                     instrument gain information. It has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency'. Must be
                                                 specified (no defaults)
-                                    'gains'     [scalar or numpy array] 
-                                                Complex baseline-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex baseline-based
+                                                instrument gains. Must be
                                                 of shape (nax1, nax2, nax3)
                                                 where ax1, ax2 and ax3 are
-                                                specified by the axes 
+                                                specified by the axes
                                                 ordering under key 'ordering'.
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -170,62 +170,62 @@ def read_gaintable(gainsfile, axes_order=None):
                                                 For example, shapes (nax1,1,1),
                                                 (1,1,1), (1,nax2,nax3) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
                                                 'label', 'frequency' and 'time'
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List of baseline labels that
                                                 correspond to the nax along
                                                 the 'label' axis. If the
                                                 nax=1 along the 'label' axis
                                                 this may be set to None, else
                                                 it must be specified and must
-                                                match the nax. 
-                                    'frequency' [None or list or numpy array] 
+                                                match the nax.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nax=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nax. 
-                                    'time'      [None or list or numpy array] 
+                                                nax=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nax.
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                nax=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
+                                                nax=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
                                                 must match the nax. It must be
-                                                a float and can be in seconds, 
+                                                a float and can be in seconds,
                                                 hours, days, etc.
 
-    axes_order  [None or list or numpy array] The gaintable which is read is 
-                stored in this axes ordering. If set to None, it will store in 
+    axes_order  [None or list or numpy array] The gaintable which is read is
+                stored in this axes ordering. If set to None, it will store in
                 this order ['label', 'frequency', 'time']
 
     Output:
 
     gaintable   [None or dictionary] If set to None, all antenna- and baseline-
                 based gains must be set to unity. If returned as dictionary, it
-                contains the loaded gains. It contains the following keys and 
+                contains the loaded gains. It contains the following keys and
                 values:
-                'antenna-based'     [None or dictionary] Contains antenna-based 
-                                    instrument gain information. If set to None, 
-                                    all antenna-based gains are set to unity. 
+                'antenna-based'     [None or dictionary] Contains antenna-based
+                                    instrument gain information. If set to None,
+                                    all antenna-based gains are set to unity.
                                     If returned as dictionary, it has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency' as specified
                                                 in input axes_order
-                                    'gains'     [scalar or numpy array] 
-                                                Complex antenna-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex antenna-based
+                                                instrument gains. Must be
                                                 of shape (nant, nchan, nts)
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -234,50 +234,50 @@ def read_gaintable(gainsfile, axes_order=None):
                                                 For example, shapes (nant,1,1),
                                                 (1,1,1), (1,nchan,nts) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
                                                 'label', 'frequency' and 'time'
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List of antenna labels that
                                                 correspond to nant along
                                                 the 'label' axis. If nant=1,
                                                 this may be set to None, else
                                                 it will be specified and will
-                                                match the nant. 
-                                    'frequency' [None or list or numpy array] 
+                                                match the nant.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan. 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan.
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
                                                 must match the ntimes. It will
                                                 be a float and in same units as
                                                 given in input
-                'baseline-based'    [None or dictionary] Contains baseline-based 
-                                    instrument gain information. If set to None, 
-                                    all baseline-based gains are set to unity. 
+                'baseline-based'    [None or dictionary] Contains baseline-based
+                                    instrument gain information. If set to None,
+                                    all baseline-based gains are set to unity.
                                     If returned as dictionary, it has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency' as specified
-                                                in input axes_order 
-                                    'gains'     [scalar or numpy array] 
-                                                Complex baseline-based 
-                                                instrument gains. Must be 
+                                                in input axes_order
+                                    'gains'     [scalar or numpy array]
+                                                Complex baseline-based
+                                                instrument gains. Must be
                                                 of shape (nbl, nchan, nts)
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -286,31 +286,31 @@ def read_gaintable(gainsfile, axes_order=None):
                                                 For example, shapes (nbl,1,1),
                                                 (1,1,1), (1,nchan,nts) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
                                                 'label', 'frequency' and 'time'
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List of baseline labels that
                                                 correspond to nbl along the
                                                 'label' axis. If nbl=1 along
-                                                the 'label' axis this may be 
-                                                set to None, else it will be 
-                                                specified and will match nbl. 
-                                    'frequency' [None or list or numpy array] 
+                                                the 'label' axis this may be
+                                                set to None, else it will be
+                                                specified and will match nbl.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan. 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan.
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
                                                 must match the ntimes. It will
                                                 be a float and in same units as
                                                 given in input
@@ -377,7 +377,7 @@ def read_gaintable(gainsfile, axes_order=None):
         gaintable = None
     if not gaintable:
         gaintable = None
-    
+
     return gaintable
 
 ################################################################################
@@ -387,30 +387,30 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
 
     """
     ---------------------------------------------------------------------------
-    Extract complex instrument gains for given baselines from the gain table. 
+    Extract complex instrument gains for given baselines from the gain table.
 
     Inputs:
 
     gaintable   [None or dictionary] If set to None, all antenna- and baseline-
                 based gains must be set to unity. If returned as dictionary, it
-                contains the loaded gains. It contains the following keys and 
+                contains the loaded gains. It contains the following keys and
                 values:
-                'antenna-based'     [None or dictionary] Contains antenna-based 
-                                    instrument gain information. If set to None, 
-                                    all antenna-based gains are set to unity. 
+                'antenna-based'     [None or dictionary] Contains antenna-based
+                                    instrument gain information. If set to None,
+                                    all antenna-based gains are set to unity.
                                     If returned as dictionary, it has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency'. Must be
                                                 specified (no defaults)
-                                    'gains'     [scalar or numpy array] 
-                                                Complex antenna-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex antenna-based
+                                                instrument gains. Must be
                                                 of shape (nant, nchan, nts)
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -419,51 +419,51 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
                                                 For example, shapes (nant,1,1),
                                                 (1,1,1), (1,nchan,nts) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
-                                                'label', 'frequency' and 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
+                                                'label', 'frequency' and
                                                 'time'.
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List or antenna labels that
                                                 correspond to nant along
                                                 the 'label' axis. If nant=1,
                                                 this may be set to None, else
                                                 it will be specified and will
-                                                match the nant. 
-                                    'frequency' [None or list or numpy array] 
+                                                match the nant.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the ntimes. It must 
-                                                be a float and can be in 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the ntimes. It must
+                                                be a float and can be in
                                                 seconds, hours, days, etc.
-                'baseline-based'    [None or dictionary] Contains baseline-based 
-                                    instrument gain information. If set to None, 
-                                    all baseline-based gains are set to unity. 
+                'baseline-based'    [None or dictionary] Contains baseline-based
+                                    instrument gain information. If set to None,
+                                    all baseline-based gains are set to unity.
                                     If returned as dictionary, it has the
                                     following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency'. Must be
                                                 specified (no defaults)
-                                    'gains'     [scalar or numpy array] 
-                                                Complex baseline-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex baseline-based
+                                                instrument gains. Must be
                                                 of shape (nbl, nchan, nts)
-                                                If there is no variations in 
+                                                If there is no variations in
                                                 gains along an axis, then the
                                                 corresponding nax may be set
                                                 to 1 and the gains will be
@@ -472,61 +472,61 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
                                                 For example, shapes (nant,1,1),
                                                 (1,1,1), (1,nchan,nts) are
                                                 acceptable. If specified as a
-                                                scalar, it will be replicated 
-                                                along all three axes, namely, 
-                                                'label', 'frequency' and 
+                                                scalar, it will be replicated
+                                                along all three axes, namely,
+                                                'label', 'frequency' and
                                                 'time'.
-                                    'label'     [None or list or numpy array] 
+                                    'label'     [None or list or numpy array]
                                                 List or baseline labels that
                                                 correspond to nbl along
-                                                the 'label' axis. If nbl=1 
+                                                the 'label' axis. If nbl=1
                                                 along the 'label' axis
                                                 this may be set to None, else
                                                 it will be specified and will
-                                                match nbl. 
-                                    'frequency' [None or list or numpy array] 
+                                                match nbl.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the ntimes. It must 
-                                                be a float and can be in 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the ntimes. It must
+                                                be a float and can be in
                                                 seconds, hours, days, etc.
 
-    bl_labels   [Numpy structured array tuples] Labels of antennas in the pair 
-                used to produce the baseline vector under fields 'A2' and 'A1' 
-                for second and first antenna respectively. The baseline vector 
-                is obtained by position of antennas under 'A2' minus position 
+    bl_labels   [Numpy structured array tuples] Labels of antennas in the pair
+                used to produce the baseline vector under fields 'A2' and 'A1'
+                for second and first antenna respectively. The baseline vector
+                is obtained by position of antennas under 'A2' minus position
                 of antennas under 'A1'
 
-    freq_index  [None, int, list or numpy array] Index (scalar) or indices 
-                (list or numpy array) along the frequency axis at which gains 
-                are to be extracted. If set to None, gains at all frequencies 
-                in the gain table will be extracted. 
+    freq_index  [None, int, list or numpy array] Index (scalar) or indices
+                (list or numpy array) along the frequency axis at which gains
+                are to be extracted. If set to None, gains at all frequencies
+                in the gain table will be extracted.
 
-    time_index  [None, int, list or numpy array] Index (scalar) or indices 
-                (list or numpy array) along the time axis at which gains 
-                are to be extracted. If set to None, gains at all timesin the 
-                gain table will be extracted. 
+    time_index  [None, int, list or numpy array] Index (scalar) or indices
+                (list or numpy array) along the time axis at which gains
+                are to be extracted. If set to None, gains at all timesin the
+                gain table will be extracted.
 
-    axes_order  [None or list or numpy array] Axes ordering for extracted 
-                gains. It must contain the three elements 'label', 
-                'frequency', and 'time'. If set to None, it will be returned 
-                in the same order as in the input gaintable. 
+    axes_order  [None or list or numpy array] Axes ordering for extracted
+                gains. It must contain the three elements 'label',
+                'frequency', and 'time'. If set to None, it will be returned
+                in the same order as in the input gaintable.
 
-    Outputs: 
+    Outputs:
 
-    [numpy array] Complex gains of shape nbl x nchan x nts for the specified 
+    [numpy array] Complex gains of shape nbl x nchan x nts for the specified
     baselines, frequencies and times.
     ---------------------------------------------------------------------------
     """
@@ -550,7 +550,7 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
                     gains = NP.copy(gaintable[gainkey]['gains'])
                 else:
                     gains = NP.transpose(NP.copy(gaintable[gainkey]['gains']), axes=temp_transpose_order)
-                
+
                 if freq_index is None:
                     freq_index = NP.arange(gains.shape[1])
                 elif isinstance(freq_index, (int,list,NP.ndarray)):
@@ -563,7 +563,7 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
                     time_index = NP.asarray(time_index).ravel()
                 if NP.any(time_index >= gains.shape[2]):
                     raise IndexError('Input time_index cannot exceed the time dimensions in the gain table')
-    
+
                 if gains.shape[0] == 1:
                     blgains = blgains * gains[:,freq_index,time_index].reshape(1,freq_index.size,time_index.size)
                 else:
@@ -604,31 +604,31 @@ def extract_gains(gaintable, bl_labels, freq_index=None, time_index=None,
 
 ################################################################################
 
-def hexagon_generator(spacing, n_total=None, n_side=None, orientation=None, 
+def hexagon_generator(spacing, n_total=None, n_side=None, orientation=None,
                       center=None):
-    
+
     """
     ------------------------------------------------------------------------
-    Generate a grid of baseline locations filling a regular hexagon. 
+    Generate a grid of baseline locations filling a regular hexagon.
     Primarily intended for HERA experiment.
 
     Inputs:
-    
+
     spacing      [scalar] positive scalar specifying the spacing between
                  antennas. Must be specified, no default.
 
     n_total      [scalar] positive integer specifying the total number of
                  antennas to be placed in the hexagonal array. This value
                  will be checked if it valid for a regular hexagon. If
-                 n_total is specified, n_side must not be specified. 
+                 n_total is specified, n_side must not be specified.
                  Default = None.
 
     n_side       [scalar] positive integer specifying the number of antennas
                  on the side of the hexagonal array. If n_side is specified,
                  n_total should not be specified. Default = None
 
-    orientation  [scalar] counter-clockwise angle (in degrees) by which the 
-                 principal axis of the hexagonal array is to be rotated. 
+    orientation  [scalar] counter-clockwise angle (in degrees) by which the
+                 principal axis of the hexagonal array is to be rotated.
                  Default = None (means 0 degrees)
 
     center       [2-element list or numpy array] specifies the center of the
@@ -646,7 +646,7 @@ def hexagon_generator(spacing, n_total=None, n_side=None, orientation=None,
     id           [numpy array of string] unique antenna identifier. Numbers
                  from 0 to n_antennas-1 in string format.
 
-    Notes: 
+    Notes:
 
     If n_side is the number of antennas on the side of the hexagon, then
     n_total = 3*n_side**2 - 3*n_side + 1
@@ -663,7 +663,7 @@ def hexagon_generator(spacing, n_total=None, n_side=None, orientation=None,
 
     if spacing <= 0:
         raise ValueError('spacing must be positive')
-        
+
     if orientation is not None:
         if not isinstance(orientation, (int,float)):
             raise TypeError('orientation must be a scalar')
@@ -728,7 +728,7 @@ def hexagon_generator(spacing, n_total=None, n_side=None, orientation=None,
     xy = xy - NP.mean(xy, axis=0, keepdims=True)    # Shift the center to origin
     if orientation is not None:   # Perform any rotation
         angle = NP.radians(orientation)
-        rot_matrix = NP.asarray([[NP.cos(angle), -NP.sin(angle)], 
+        rot_matrix = NP.asarray([[NP.cos(angle), -NP.sin(angle)],
                                  [NP.sin(angle), NP.cos(angle)]])
         xy = NP.dot(xy, rot_matrix.T)
 
@@ -744,20 +744,20 @@ def rectangle_generator(spacing, n_side, orientation=None, center=None):
 
     """
     ------------------------------------------------------------------------
-    Generate a grid of baseline locations filling a rectangular array. 
+    Generate a grid of baseline locations filling a rectangular array.
     Primarily intended for HIRAX, CHIME and PAPER experiments
 
     Inputs:
-    
-    spacing      [2-element list or numpy array] positive integers specifying 
+
+    spacing      [2-element list or numpy array] positive integers specifying
     		 the spacing between antennas. Must be specified, no default.
 
-    n_side       [2-element list or numpy array] positive integers specifying 
-    		 the number of antennas on each side of the rectangular array. 
+    n_side       [2-element list or numpy array] positive integers specifying
+    		 the number of antennas on each side of the rectangular array.
     		 Atleast one value should be specified, no default.
 
-    orientation  [scalar] counter-clockwise angle (in degrees) by which the 
-                 principal axis of the rectangular array is to be rotated. 
+    orientation  [scalar] counter-clockwise angle (in degrees) by which the
+                 principal axis of the rectangular array is to be rotated.
                  Default = None (means 0 degrees)
 
     center       [2-element list or numpy array] specifies the center of the
@@ -775,7 +775,7 @@ def rectangle_generator(spacing, n_side, orientation=None, center=None):
     id           [numpy array of string] unique antenna identifier. Numbers
                  from 0 to n_antennas-1 in string format.
 
-    Notes: 
+    Notes:
 
     ------------------------------------------------------------------------
     """
@@ -815,7 +815,7 @@ def rectangle_generator(spacing, n_side, orientation=None, center=None):
             n_side = NP.resize(n_side,(1,2))
         if NP.all(NP.less_equal(n_side,NP.zeros((1,2)))):
             raise ValueError('n_side must be positive')
-	
+
 	n_total = NP.prod(n_side, dtype=NP.uint8)
 	xn,yn = NP.hsplit(n_side,2)
 	xn = NP.asscalar(xn)
@@ -866,21 +866,21 @@ def circular_antenna_array(antsize, minR, maxR=None):
     antsize   [scalar] Antenna size. Critical to determining number of antenna
               elements that can be placed on a circle. No default.
 
-    minR      [scalar] Minimum radius of the circular ring. Must be in same 
+    minR      [scalar] Minimum radius of the circular ring. Must be in same
               units as antsize. No default. Must be greater than 0.5*antsize.
 
-    maxR      [scalar] Maximum radius of circular ring. Must be >= minR. 
+    maxR      [scalar] Maximum radius of circular ring. Must be >= minR.
               Default=None means maxR is set equal to minR.
 
     Outputs:
 
-    xy        [2-column numpy array] Antenna locations in the same units as 
+    xy        [2-column numpy array] Antenna locations in the same units as
               antsize returned as a 2-column numpy array where the number of
-              rows equals the number of antenna locations generated and x, 
+              rows equals the number of antenna locations generated and x,
               and y locations make the two columns.
     ---------------------------------------------------------------------------
     """
-    
+
     try:
         antsize, minR
     except NameError:
@@ -904,7 +904,7 @@ def circular_antenna_array(antsize, minR, maxR=None):
 
     if maxR is None:
         maxR = minR
-        
+
     if not isinstance(maxR, (int, float)):
         raise TypeError('maxR must be a scalar')
     elif maxR < minR:
@@ -912,7 +912,7 @@ def circular_antenna_array(antsize, minR, maxR=None):
 
     if maxR - minR < antsize:
         radii = minR + NP.zeros(1)
-    else:    
+    else:
         radii = minR + antsize * NP.arange((maxR-minR)/antsize)
     nants = 2 * NP.pi * radii / antsize
     nants = nants.astype(NP.int)
@@ -940,7 +940,7 @@ def baseline_generator(antenna_locations, ant_label=None, ant_id=None,
 
     Inputs:
 
-    antenna_locations: List of tuples containing antenna coordinates, 
+    antenna_locations: List of tuples containing antenna coordinates,
                        or list of instances of class Point containing
                        antenna coordinates, or Numpy array (Nx3) array
                        with each row specifying an antenna location.
@@ -960,30 +960,30 @@ def baseline_generator(antenna_locations, ant_label=None, ant_id=None,
     auto:              [Default=False] If True, compute zero spacings of
                        antennas with themselves.
 
-    conjugate:         [Default=False] If True, compute conjugate 
+    conjugate:         [Default=False] If True, compute conjugate
                        baselines.
 
     Output:
 
-    baseline_locations: Baseline locations in the same data type as 
-                        antenna locations (list of tuples, list of 
+    baseline_locations: Baseline locations in the same data type as
+                        antenna locations (list of tuples, list of
                         instances of class Point or Numpy array of size
-                        Nb x 3 with each row specifying one baseline 
+                        Nb x 3 with each row specifying one baseline
                         vector)
 
-    antpair_labels      [Numpy structured array tuples] Labels of 
-                        antennas in the pair used to produce the 
-                        baseline vector under fields 'A2' and 'A1' for 
-                        second and first antenna respectively. The 
-                        baseline vector is obtained by position of 
-                        antennas under 'A2' minus position of antennas 
+    antpair_labels      [Numpy structured array tuples] Labels of
+                        antennas in the pair used to produce the
+                        baseline vector under fields 'A2' and 'A1' for
+                        second and first antenna respectively. The
+                        baseline vector is obtained by position of
+                        antennas under 'A2' minus position of antennas
                         under 'A1'
 
-    antpair_ids         [Numpy structured array tuples] IDs of antennas 
+    antpair_ids         [Numpy structured array tuples] IDs of antennas
                         in the pair used to produce the baseline vector
-                        under fields 'A2' and 'A1' for second and first 
-                        antenna respectively. The baseline vector is 
-                        obtained by position of antennas under 'A2' 
+                        under fields 'A2' and 'A1' for second and first
+                        antenna respectively. The baseline vector is
+                        obtained by position of antennas under 'A2'
                         minus position of antennas under 'A1'
     -------------------------------------------------------------------
     """
@@ -1061,7 +1061,7 @@ def baseline_generator(antenna_locations, ant_label=None, ant_id=None,
             ant_id = ant_id.tolist()
     else:
         ant_id = range(num_ants)
-        
+
     if inp_type == 'loo':
         if auto:
             baseline_locations = [antenna_locations[j]-antenna_locations[i] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j >= i]
@@ -1069,7 +1069,7 @@ def baseline_generator(antenna_locations, ant_label=None, ant_id=None,
             antpair_labels = [(ant_label[j], ant_label[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j >= i]
             antpair_ids = [(ant_id[j], ant_id[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j >= i]
         else:
-            baseline_locations = [antenna_locations[j]-antenna_locations[i] for i in range(0,num_ants) for j in range(0,num_ants) if j > i]                
+            baseline_locations = [antenna_locations[j]-antenna_locations[i] for i in range(0,num_ants) for j in range(0,num_ants) if j > i]
             # antpair_labels = [ant_label[j]+'-'+ant_label[i] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
             antpair_labels = [(ant_label[j], ant_label[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
             antpair_ids = [(ant_id[j], ant_id[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
@@ -1101,12 +1101,12 @@ def baseline_generator(antenna_locations, ant_label=None, ant_id=None,
             antpair_labels = [(ant_label[j], ant_label[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j >= i]
             antpair_ids = [(ant_id[j], ant_id[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j >= i]
         else:
-            baseline_locations = [antenna_locations[j,:]-antenna_locations[i,:] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]  
+            baseline_locations = [antenna_locations[j,:]-antenna_locations[i,:] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
             # antpair_labels = [ant_label[j]+'-'+ant_label[i] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
             antpair_labels = [(ant_label[j], ant_label[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
             antpair_ids = [(ant_id[j], ant_id[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j > i]
         if conjugate:
-            baseline_locations += [antenna_locations[j,:]-antenna_locations[i,:] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j < i]         
+            baseline_locations += [antenna_locations[j,:]-antenna_locations[i,:] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j < i]
             # antpair_labels += [ant_label[j]+'-'+ant_label[i] for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j < i]
             antpair_labels += [(ant_label[j], ant_label[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j < i]
             antpair_ids += [(ant_id[j], ant_id[i]) for i in xrange(0,num_ants) for j in xrange(0,num_ants) if j < i]
@@ -1128,26 +1128,26 @@ def uniq_baselines(baseline_locations, redundant=None):
     baseline locations.
 
     Inputs:
-    
-    baseline_locations [2- or 3-column numpy array] Each row of the array 
-                       specifies a baseline vector from which the required 
+
+    baseline_locations [2- or 3-column numpy array] Each row of the array
+                       specifies a baseline vector from which the required
                        set of baselines have to be identified
 
-    redundant          [None or boolean] If set to None (default), all the 
+    redundant          [None or boolean] If set to None (default), all the
                        unique baselines including redundant and non-redundant
                        baselines are returned. If set to True, only redundant
                        baselines that occur more than once are returned. If set
-                       to False, only non-redundant baselines that occur 
+                       to False, only non-redundant baselines that occur
                        exactly once are returned.
 
     Output:
 
     3-element tuple with the selected baselines, their indices in the input,
-    and their count. The first element of this tuple is a 3-column numpy array 
-    which is a subset of baseline_locations containing the requested type of 
-    baselines. The second element of the tuple contains the count of these 
-    selected baselines. In case of redundant and unique baselines, the order 
-    of repeated baselines does not matter and any one of those baselines could 
+    and their count. The first element of this tuple is a 3-column numpy array
+    which is a subset of baseline_locations containing the requested type of
+    baselines. The second element of the tuple contains the count of these
+    selected baselines. In case of redundant and unique baselines, the order
+    of repeated baselines does not matter and any one of those baselines could
     be returned without preserving the order.
     ---------------------------------------------------------------------------
     """
@@ -1156,7 +1156,7 @@ def uniq_baselines(baseline_locations, redundant=None):
         baseline_locations
     except NameError:
         raise NameError('baseline_locations not provided')
-        
+
     if not isinstance(baseline_locations, NP.ndarray):
         raise TypeError('baseline_locations must be a numpy array')
 
@@ -1200,7 +1200,7 @@ def uniq_baselines(baseline_locations, redundant=None):
             redn_ind, counts = zip(*redn_ind_counts)
             retind = ind[NP.asarray(redn_ind)]
             counts = NP.asarray(counts)
-            
+
     return (baseline_locations[retind,:], retind, counts)
 
 #################################################################################
@@ -1222,54 +1222,54 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
               element size and orientation. It consists of the following keys
               and values:
               'latitude'    [float] latitude of the telescope site (in degrees).
-                            If this key is not present, the latitude of MWA 
+                            If this key is not present, the latitude of MWA
                             (-26.701 degrees) will be assumed.
               'id'          [string] If set, will ignore the other keys and use
-                            telescope details for known telescopes. Accepted 
-                            values are 'mwa', 'vla', 'gmrt', and 'hera', 
+                            telescope details for known telescopes. Accepted
+                            values are 'mwa', 'vla', 'gmrt', and 'hera',
                             'paper', 'hirax' and 'chime'
               'shape'       [string] Shape of antenna element. Accepted values
-                            are 'dipole', 'delta', and 'dish'. Will be ignored 
+                            are 'dipole', 'delta', and 'dish'. Will be ignored
                             if key 'id' is set. 'delta' denotes a delta
                             function for the antenna element which has an
                             isotropic radiation pattern. 'delta' is the default
                             when keys 'id' and 'shape' are not set.
-              'size'        [scalar] Diameter of the telescope dish (in meters) 
-                            if the key 'shape' is set to 'dish' or length of 
-                            the dipole if key 'shape' is set to 'dipole'. Will 
-                            be ignored if key 'shape' is set to 'delta'. Will 
-                            be ignored if key 'id' is set and a preset value 
+              'size'        [scalar] Diameter of the telescope dish (in meters)
+                            if the key 'shape' is set to 'dish' or length of
+                            the dipole if key 'shape' is set to 'dipole'. Will
+                            be ignored if key 'shape' is set to 'delta'. Will
+                            be ignored if key 'id' is set and a preset value
                             used for the diameter or dipole.
-              'orientation' [list or numpy array] If key 'shape' is set to 
-                            dipole, it refers to the orientation of the dipole 
-                            element unit vector whose magnitude is specified by 
-                            length. If key 'shape' is set to 'dish', it refers 
+              'orientation' [list or numpy array] If key 'shape' is set to
+                            dipole, it refers to the orientation of the dipole
+                            element unit vector whose magnitude is specified by
+                            length. If key 'shape' is set to 'dish', it refers
                             to the position on the sky to which the dish is
                             pointed. For a dipole, this unit vector must be
-                            provided in the local ENU coordinate system aligned 
+                            provided in the local ENU coordinate system aligned
                             with the direction cosines coordinate system or in
                             the Alt-Az coordinate system. This will be
                             used only when key 'shape' is set to 'dipole'.
-                            This could be a 2-element vector (transverse 
-                            direction cosines) where the third (line-of-sight) 
+                            This could be a 2-element vector (transverse
+                            direction cosines) where the third (line-of-sight)
                             component is determined, or a 3-element vector
                             specifying all three direction cosines or a two-
-                            element coordinate in Alt-Az system. If not provided 
+                            element coordinate in Alt-Az system. If not provided
                             it defaults to an eastward pointing dipole. If key
-                            'shape' is set to 'dish', the orientation refers 
+                            'shape' is set to 'dish', the orientation refers
                             to the pointing center of the dish on the sky. It
                             can be provided in Alt-Az system as a two-element
                             vector or in the direction cosine coordinate
                             system as a two- or three-element vector. If not
-                            set in the case of a dish element, it defaults to 
+                            set in the case of a dish element, it defaults to
                             zenith. This is not to be confused with the key
-                            'pointing_center' in dictionary 'pointing_info' 
+                            'pointing_center' in dictionary 'pointing_info'
                             which refers to the beamformed pointing center of
-                            the array. The coordinate system is specified by 
+                            the array. The coordinate system is specified by
                             the key 'ocoords'
-              'ocoords'     [scalar string] specifies the coordinate system 
+              'ocoords'     [scalar string] specifies the coordinate system
                             for key 'orientation'. Accepted values are 'altaz'
-                            and 'dircos'. 
+                            and 'dircos'.
               'element_locs'
                             [2- or 3-column array] Element locations that
                             constitute the tile. Each row specifies
@@ -1277,29 +1277,29 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
                             locations must be specified in local ENU
                             coordinate system. First column specifies along
                             local east, second along local north and the
-                            third along local up. If only two columns are 
-                            specified, the third column is assumed to be 
+                            third along local up. If only two columns are
+                            specified, the third column is assumed to be
                             zeros. If 'elements_locs' is not provided, it
                             assumed to be a one-element system and not a
-                            phased array as far as determination of primary 
+                            phased array as far as determination of primary
                             beam is concerned.
-              'groundplane' [scalar] height of telescope element above the 
+              'groundplane' [scalar] height of telescope element above the
                             ground plane (in meteres). Default = None will
                             denote no ground plane effects.
               'ground_modify'
                             [dictionary] contains specifications to modify
                             the analytically computed ground plane pattern. If
                             absent, the ground plane computed will not be
-                            modified. If set, it may contain the following 
+                            modified. If set, it may contain the following
                             keys:
-                            'scale' [scalar] positive value to scale the 
-                                    modifying factor with. If not set, the 
+                            'scale' [scalar] positive value to scale the
+                                    modifying factor with. If not set, the
                                     scale factor to the modification is unity.
-                            'max'   [scalar] positive value to clip the 
-                                    modified and scaled values to. If not set, 
+                            'max'   [scalar] positive value to clip the
+                                    modified and scaled values to. If not set,
                                     there is no upper limit
 
-    pointing_info 
+    pointing_info
               [dictionary] Contains information about the pointing. It carries
               the following keys and values:
 
@@ -1307,28 +1307,28 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
 
               'pointing_coords'
                        [string scalar] Coordinate system in which the
-                       pointing_center is specified. Accepted values are 
+                       pointing_center is specified. Accepted values are
                        'radec', 'hadec', 'altaz' or 'dircos'. Must be specified
                        if pointing_center is specified
 
               'pointing_center'
-                       [numpy array] coordinates of pointing center (in the 
-                       coordinate system specified under key 'pointing_coords'). 
+                       [numpy array] coordinates of pointing center (in the
+                       coordinate system specified under key 'pointing_coords').
                        Mx2 array when value under key 'pointing_coords' is set
                        to 'radec', 'hadec' or 'altaz', or Mx3 array when the
                        value in 'pointing_coords' is set to 'dircos'. Number of
-                       rows M should be equal to number of pointings and LST. 
+                       rows M should be equal to number of pointings and LST.
                        If only one row (M=1) is provided the same pointing
                        center in the given coordinate system will apply to all
                        pointings.
 
-    freq_scale 
-              [string scalar] Units of frequency. Accepted values are 'Hz', 
+    freq_scale
+              [string scalar] Units of frequency. Accepted values are 'Hz',
               'kHz', 'MHz' or 'GHz'. If None provided, default is set to 'GHz'
 
     Output:
 
-    2-dimensional numpy array containing the antenna power. The rows denote 
+    2-dimensional numpy array containing the antenna power. The rows denote
     the different pointings and columns denote the frequency spectrum obtained
     from the frequencies specified in the sky model.
 
@@ -1353,7 +1353,7 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
 
     if not isinstance(pointing_info, dict):
         raise TypeError('Input parameter pointing_info must be a dictionary')
-    
+
     if 'latitude' in telescope_info:
         latitude = telescope_info['latitude']
     else:
@@ -1390,7 +1390,7 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
             raise ValueError('Value under key "pointing_center" in input parameter pointing_info must be a 2-column array for RA-Dec, HA-Dec and Alt-Az coordinate systems')
 
         n_pointings = pointing_center.shape[0]
-        
+
         if (n_pointings != n_lst) and (n_pointings != 1):
             raise ValueError('Number of pointing centers and number of LST must match')
         if n_pointings < n_lst:
@@ -1410,9 +1410,9 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
     if skymodel.coords == 'radec':
         lst_temp = NP.hstack((lst.reshape(-1,1),NP.zeros(n_snaps).reshape(-1,1)))  # Prepare fake LST for numpy broadcasting
         lst_temp = lst_temp.T
-        lst_temp = lst_temp[NP.newaxis,:,:]  
+        lst_temp = lst_temp[NP.newaxis,:,:]
         sky_hadec = lst_temp - skymodel.location[:,:,NP.newaxis]  # Reverses sign of declination
-        sky_hadec[:,1,:] *= -1   # Correct for the reversal of sign in the declination 
+        sky_hadec[:,1,:] *= -1   # Correct for the reversal of sign in the declination
         sky_hadec = NP.concatenate(NP.split(sky_hadec, n_snaps, axis=2), axis=0)
         sky_hadec = NP.squeeze(sky_hadec, axis=2)
         sky_altaz = GEOM.hadec2altaz(sky_hadec, latitude, units='degrees')
@@ -1433,7 +1433,7 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
         pinfo['pointing_coords'] = 'altaz'
         # if 'element_locs' in telescope_info:
         #     pinfo['element_locs'] = telescope_info['element_locs']
-        
+
         upper_hemisphere_ind = sky_altaz[i][:,0] >= 0.0
         upper_skymodel = skymodel.subset(indices=NP.where(upper_hemisphere_ind)[0])
         pb = PB.primary_beam_generator(sky_altaz[i][upper_hemisphere_ind,:], skymodel.frequency, telescope_info, freq_scale=freq_scale, skyunits='altaz', pointing_info=pinfo)
@@ -1445,7 +1445,7 @@ def antenna_power(skymodel, telescope_info, pointing_info, freq_scale=None):
     progress.finish()
 
     return NP.asarray(retval)
-        
+
 #################################################################################
 
 class GainInfo(object):
@@ -1456,168 +1456,168 @@ class GainInfo(object):
 
     Attributes:
 
-    gaintable   [None or dictionary] If set to None, all antenna- and 
-                baseline-based gains will be set to unity. If returned as 
-                dictionary, it contains the loaded gains. It contains the 
+    gaintable   [None or dictionary] If set to None, all antenna- and
+                baseline-based gains will be set to unity. If returned as
+                dictionary, it contains the loaded gains. It contains the
                 following keys and values:
                 'antenna-based'     [None or dictionary] Contains antenna-
-                                    based instrument gain information. If 
-                                    set to None, all antenna-based gains are 
-                                    set to unity. If returned as dictionary, 
+                                    based instrument gain information. If
+                                    set to None, all antenna-based gains are
+                                    set to unity. If returned as dictionary,
                                     it has the following keys and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
+                                                axes - 'time', 'label',
                                                 and 'frequency' as specified
                                                 in input axes_order
-                                    'gains'     [scalar or numpy array] 
-                                                Complex antenna-based 
-                                                instrument gains. Must be 
+                                    'gains'     [scalar or numpy array]
+                                                Complex antenna-based
+                                                instrument gains. Must be
                                                 of shape (nant, nchan, nts)
-                                                If there is no variations in 
-                                                gains along an axis, then 
-                                                the corresponding nax may be 
-                                                set to 1 and the gains will 
-                                                be replicated along that 
-                                                axis using numpy array 
-                                                broadcasting. For example, 
-                                                shapes (nant,1,1), (1,1,1), 
-                                                (1,nchan,nts) are 
-                                                acceptable. If specified as 
-                                                a scalar, it will be 
-                                                replicated along all three 
-                                                axes, namely, 'label', 
+                                                If there is no variations in
+                                                gains along an axis, then
+                                                the corresponding nax may be
+                                                set to 1 and the gains will
+                                                be replicated along that
+                                                axis using numpy array
+                                                broadcasting. For example,
+                                                shapes (nant,1,1), (1,1,1),
+                                                (1,nchan,nts) are
+                                                acceptable. If specified as
+                                                a scalar, it will be
+                                                replicated along all three
+                                                axes, namely, 'label',
                                                 'frequency' and 'time'.
-                                    'label'     [None or list or numpy 
-                                                array] List or antenna 
-                                                labels that correspond to 
-                                                nant along the 'label' axis. 
-                                                If nant=1, this may be set 
-                                                to None, else it will be 
-                                                specified and will match the 
-                                                nant. 
-                                    'frequency' [None or list or numpy array] 
+                                    'label'     [None or list or numpy
+                                                array] List or antenna
+                                                labels that correspond to
+                                                nant along the 'label' axis.
+                                                If nant=1, this may be set
+                                                to None, else it will be
+                                                specified and will match the
+                                                nant.
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the ntimes. It must 
-                                                be a float and can be in 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the ntimes. It must
+                                                be a float and can be in
                                                 seconds, hours, days, etc.
                 'baseline-based'    [None or dictionary] Contains baseline-
-                                    based instrument gain information. If 
-                                    set to None, all baseline-based gains 
-                                    are set to unity. If returned as 
-                                    dictionary, it has the following keys 
+                                    based instrument gain information. If
+                                    set to None, all baseline-based gains
+                                    are set to unity. If returned as
+                                    dictionary, it has the following keys
                                     and values:
                                     'ordering'  [list or numpy array] Three
-                                                element list of strings 
+                                                element list of strings
                                                 indicating the ordering of
-                                                axes - 'time', 'label', 
-                                                and 'frequency' as 
-                                                specified in input 
-                                                axes_order 
-                                    'gains'     [scalar or numpy array] 
-                                                Complex baseline-based 
-                                                instrument gains. Must be 
+                                                axes - 'time', 'label',
+                                                and 'frequency' as
+                                                specified in input
+                                                axes_order
+                                    'gains'     [scalar or numpy array]
+                                                Complex baseline-based
+                                                instrument gains. Must be
                                                 of shape (nbl, nchan, nts)
-                                                If there is no variations in 
-                                                gains along an axis, then 
-                                                the corresponding nax may be 
-                                                set to 1 and the gains will 
-                                                be replicated along that 
-                                                axis using numpy array 
-                                                broadcasting. For example, 
-                                                shapes (nant,1,1), (1,1,1), 
-                                                (1,nchan,nts) are 
-                                                acceptable. If specified as 
-                                                a scalar, it will be 
-                                                replicated along all three 
-                                                axes, namely, 'label', 
+                                                If there is no variations in
+                                                gains along an axis, then
+                                                the corresponding nax may be
+                                                set to 1 and the gains will
+                                                be replicated along that
+                                                axis using numpy array
+                                                broadcasting. For example,
+                                                shapes (nant,1,1), (1,1,1),
+                                                (1,nchan,nts) are
+                                                acceptable. If specified as
+                                                a scalar, it will be
+                                                replicated along all three
+                                                axes, namely, 'label',
                                                 'frequency' and 'time'.
-                                    'label'     [None or list or numpy 
-                                                array] List or baseline 
-                                                labels that correspond to 
-                                                nbl along the 'label' axis. 
-                                                If nbl=1 along the 'label' 
-                                                axis this may be set to 
-                                                None, else it will be 
-                                                specified and will match nbl 
-                                    'frequency' [None or list or numpy array] 
+                                    'label'     [None or list or numpy
+                                                array] List or baseline
+                                                labels that correspond to
+                                                nbl along the 'label' axis.
+                                                If nbl=1 along the 'label'
+                                                axis this may be set to
+                                                None, else it will be
+                                                specified and will match nbl
+                                    'frequency' [None or list or numpy array]
                                                 Frequency channels that
                                                 correspond to the nax along
                                                 the 'frequency' axis. If the
-                                                nchan=1 along the 'frequency' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the nchan 
-                                    'time'      [None or list or numpy array] 
+                                                nchan=1 along the 'frequency'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the nchan
+                                    'time'      [None or list or numpy array]
                                                 Observation times that
                                                 correspond to the nax along
                                                 the 'time' axis. If the
-                                                ntimes=1 along the 'time' 
-                                                axis, this may be set to None, 
-                                                else it must be specified and 
-                                                must match the ntimes. It must 
-                                                be a float and can be in 
+                                                ntimes=1 along the 'time'
+                                                axis, this may be set to None,
+                                                else it must be specified and
+                                                must match the ntimes. It must
+                                                be a float and can be in
                                                 seconds, hours, days, etc.
 
-    interpfuncs [dictionary] Determined in member function interpolator(). 
-                Contains interpolation information under two keys, namely, 
-                'antenna-based' and 'baseline-based'. Under each of these keys 
+    interpfuncs [dictionary] Determined in member function interpolator().
+                Contains interpolation information under two keys, namely,
+                'antenna-based' and 'baseline-based'. Under each of these keys
                 is another dictionary with the following keys and values:
                 'dims'      [numpy array of strings] Contains the axes labels
-                            of the interpolated axes for antenna or baseline 
-                            labels. It could contain a single element ['time'], 
+                            of the interpolated axes for antenna or baseline
+                            labels. It could contain a single element ['time'],
                             of ['frequency'] indicating 1D splines along that
                             axis or contain two elements 'time' and 'frequency'
                             indicating 2D splines. 1D splines will have been
                             obtained with scipy.interpolate.interp1d while
                             2D splines obtained with scipy.interpolate.interp2d
                 'interp'    [numpy recArray] Holds the interpolation functions
-                            (instances of scipy.interpolate.interp1d or 
+                            (instances of scipy.interpolate.interp1d or
                             scipy.interpolate.interp2d depending on the value
                             under 'dims' key) for each antenna or baseline
-                            label. It is of size nbl. Each entry in this 
-                            numpy recArray has two fields, 'real' for 
+                            label. It is of size nbl. Each entry in this
+                            numpy recArray has two fields, 'real' for
                             interpolation of real part and 'imag' for the
-                            imaginary part. If it is a one element recarray, 
+                            imaginary part. If it is a one element recarray,
                             then it applies to all antennas and baselines
-                Member function interpolate_gains() uses this attribute to 
+                Member function interpolate_gains() uses this attribute to
                 return interpolated gains
-                         
-    splinefuncs [dictionary] Determined in member function splinator(). 
-                Contains spline information under two keys, namely, 
-                'antenna-based' and 'baseline-based'. Under each of these keys 
+
+    splinefuncs [dictionary] Determined in member function splinator().
+                Contains spline information under two keys, namely,
+                'antenna-based' and 'baseline-based'. Under each of these keys
                 is another dictionary with the following keys and values:
                 'dims'      [numpy array of strings] Contains the axes labels
-                            of the interpolated axes for antenna or baseline 
-                            labels. It could contain a single element ['time'], 
+                            of the interpolated axes for antenna or baseline
+                            labels. It could contain a single element ['time'],
                             of ['frequency'] indicating 1D splines along that
                             axis or contain two elements 'time' and 'frequency'
                             indicating 2D splines. 1D splines will have been
-                            obtained with scipy.interpolate.UnivariateSpline 
-                            while 2D splines obtained with 
+                            obtained with scipy.interpolate.UnivariateSpline
+                            while 2D splines obtained with
                             scipy.interpolate.RectBivariateSpline
                 'interp'    [numpy recArray] Holds the spline functions
-                            (instances of scipy.interpolate.UnivariateSpline or 
-                            scipy.interpolate.RectBivariateSpline depending on 
-                            the value under 'dims' key) for each antenna or 
-                            baseline label. It is of size nbl. Each entry in 
-                            this numpy recArray has two fields, 'real' for 
+                            (instances of scipy.interpolate.UnivariateSpline or
+                            scipy.interpolate.RectBivariateSpline depending on
+                            the value under 'dims' key) for each antenna or
+                            baseline label. It is of size nbl. Each entry in
+                            this numpy recArray has two fields, 'real' for
                             interpolation of real part and 'imag' for the
-                            imaginary part. If it is a one element recarray, 
+                            imaginary part. If it is a one element recarray,
                             then it applies to all antennas and baselines.
                 Member function spline_gains() uses this attribute to return
                 spline-interpolated gains
@@ -1627,36 +1627,36 @@ class GainInfo(object):
     __init__()  Initialize an instance of class GainInfo from a file
 
     read_gaintable()
-                Read gain table from file in HDF5 format and return and/or 
+                Read gain table from file in HDF5 format and return and/or
                 store as attribute
 
     eval_gains()
-                Extract complex instrument gains for given baselines from the 
-                gain table 
+                Extract complex instrument gains for given baselines from the
+                gain table
 
     interpolator()
-                Sets up interpolation functions and stores them in the 
+                Sets up interpolation functions and stores them in the
                 attribute interpfuncs. Better alternative is to use splinator()
 
-    splinator() Sets up spline functions and stores them in the attribute 
+    splinator() Sets up spline functions and stores them in the attribute
                 splinefuncs. Better alternative to interpolator()
 
     interpolate_gains()
-                Interpolate at the specified baselines for the given 
-                frequencies and times using attribute interpfuncs. Better 
+                Interpolate at the specified baselines for the given
+                frequencies and times using attribute interpfuncs. Better
                 alternative is to use spline_gains()
 
     spline_gains()
-                Evaluate spline at the specified baselines for the given 
-                frequencies and times using attribute splinefuncs. Better 
+                Evaluate spline at the specified baselines for the given
+                frequencies and times using attribute splinefuncs. Better
                 alternative to interpolate_gains()
 
     nearest_gains()
-                Extract complex instrument gains for given baselines from the 
+                Extract complex instrument gains for given baselines from the
                 gain table determined by nearest neighbor logic
 
     write_gaintable()
-                Write gain table with specified axes ordering to external file 
+                Write gain table with specified axes ordering to external file
                 in HDF5 format
     -----------------------------------------------------------------------------
     """
@@ -1667,7 +1667,7 @@ class GainInfo(object):
         ------------------------------------------------------------------------
         Initialize an instance of class GainInfo from a file
 
-        Attributes initialized are: 
+        Attributes initialized are:
         gaintable, interpfuncs, splinefuncs
 
         Read docstring of class GainInfo for details on these attributes
@@ -1675,132 +1675,132 @@ class GainInfo(object):
         Keyword Inputs:
 
         gainsfile   [string] Filename including the full path that contains the
-                    instrument gains. It must be in HDF5 format. It must contain 
+                    instrument gains. It must be in HDF5 format. It must contain
                     the following structure:
-                    'antenna-based'     [dictionary] Contains antenna-based 
+                    'antenna-based'     [dictionary] Contains antenna-based
                                         instrument gain information. It has the
                                         following keys and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
+                                                    axes - 'time', 'label',
                                                     and 'frequency'. Must be
                                                     specified (no defaults)
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex antenna-based 
-                                                    instrument gains. Must be 
+                                        'gains'     [scalar or numpy array]
+                                                    Complex antenna-based
+                                                    instrument gains. Must be
                                                     of shape (nax1, nax2, nax3)
                                                     where ax1, ax2 and ax3 are
-                                                    specified by the axes 
-                                                    ordering under key 
-                                                    'ordering'. If there is no 
-                                                    variations in gains along an 
-                                                    axis, then the corresponding 
-                                                    nax may be set to 1 and the 
-                                                    gains will be replicated 
-                                                    along that axis using numpy 
-                                                    array broadcasting. For 
-                                                    example, shapes (nax1,1,1), 
+                                                    specified by the axes
+                                                    ordering under key
+                                                    'ordering'. If there is no
+                                                    variations in gains along an
+                                                    axis, then the corresponding
+                                                    nax may be set to 1 and the
+                                                    gains will be replicated
+                                                    along that axis using numpy
+                                                    array broadcasting. For
+                                                    example, shapes (nax1,1,1),
                                                     (1,1,1), (1,nax2,nax3) are
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy array] 
+                                        'label'     [None or list or numpy array]
                                                     List or antenna labels that
                                                     correspond to the nax along
                                                     the 'label' axis. If the
                                                     nax=1 along the 'label' axis,
                                                     this may be set to None, else
                                                     it must be specified and must
-                                                    match the nax. 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the 
-                                                    nax along the 'frequency' 
-                                                    axis. If the nax=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nax. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the nax=1 along the 'time' 
-                                                    axis, this may be set to 
-                                                    None, else it must be 
-                                                    specified and must match the 
-                                                    nax. It must be a float and 
-                                                    can be in seconds, hours, 
+                                                    match the nax.
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the
+                                                    nax along the 'frequency'
+                                                    axis. If the nax=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nax.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the nax=1 along the 'time'
+                                                    axis, this may be set to
+                                                    None, else it must be
+                                                    specified and must match the
+                                                    nax. It must be a float and
+                                                    can be in seconds, hours,
                                                     days, etc.
-                    'baseline-based'    [dictionary] Contains baseline-based 
+                    'baseline-based'    [dictionary] Contains baseline-based
                                         instrument gain information. It has the
                                         following keys and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
+                                                    axes - 'time', 'label',
                                                     and 'frequency'. Must be
                                                     specified (no defaults)
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex baseline-based 
-                                                    instrument gains. Must be 
+                                        'gains'     [scalar or numpy array]
+                                                    Complex baseline-based
+                                                    instrument gains. Must be
                                                     of shape (nax1, nax2, nax3)
                                                     where ax1, ax2 and ax3 are
-                                                    specified by the axes 
-                                                    ordering under key 
-                                                    'ordering'. If there is no 
-                                                    variations in gains along an 
-                                                    axis, then the corresponding 
-                                                    nax may be set to 1 and the 
-                                                    gains will be replicated 
-                                                    along that axis using numpy 
-                                                    array broadcasting. For 
-                                                    example, shapes (nax1,1,1), 
-                                                    (1,1,1), (1,nax2,nax3) are 
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    specified by the axes
+                                                    ordering under key
+                                                    'ordering'. If there is no
+                                                    variations in gains along an
+                                                    axis, then the corresponding
+                                                    nax may be set to 1 and the
+                                                    gains will be replicated
+                                                    along that axis using numpy
+                                                    array broadcasting. For
+                                                    example, shapes (nax1,1,1),
+                                                    (1,1,1), (1,nax2,nax3) are
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy 
-                                                    array] List of baseline 
-                                                    labels that correspond to 
-                                                    the nax along the 'label' 
-                                                    axis. If the nax=1 along the 
-                                                    'label' axis this may be set 
-                                                    to None, else it must be 
-                                                    specified and must match the 
-                                                    nax. 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the 
-                                                    nax along the 'frequency' 
-                                                    axis. If the nax=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nax. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the nax=1 along the 'time' 
-                                                    axis, this may be set to 
-                                                    None, else it must be 
-                                                    specified and must match the 
-                                                    nax. It must be a float and 
-                                                    can be in seconds, hours, 
+                                        'label'     [None or list or numpy
+                                                    array] List of baseline
+                                                    labels that correspond to
+                                                    the nax along the 'label'
+                                                    axis. If the nax=1 along the
+                                                    'label' axis this may be set
+                                                    to None, else it must be
+                                                    specified and must match the
+                                                    nax.
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the
+                                                    nax along the 'frequency'
+                                                    axis. If the nax=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nax.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the nax=1 along the 'time'
+                                                    axis, this may be set to
+                                                    None, else it must be
+                                                    specified and must match the
+                                                    nax. It must be a float and
+                                                    can be in seconds, hours,
                                                     days, etc.
-    
-        axes_order  [None or list or numpy array] The gaintable which is read is 
-                    stored in this axes ordering. If set to None, it will store 
+
+        axes_order  [None or list or numpy array] The gaintable which is read is
+                    stored in this axes ordering. If set to None, it will store
                     in this order ['label', 'frequency', 'time']
         ------------------------------------------------------------------------
         """
-    
+
         self.gaintable = None
         self.interpfuncs = {key: None for key in ['antenna-based', 'baseline-based']}
         self.splinefuncs = {key: None for key in ['antenna-based', 'baseline-based']}
@@ -1815,262 +1815,262 @@ class GainInfo(object):
 
         """
         ------------------------------------------------------------------------
-        Read gain table from file in HDF5 format and return and/or store as 
+        Read gain table from file in HDF5 format and return and/or store as
         attribute
-    
+
         Input:
-    
+
         gainsfile   [string] Filename including the full path that contains the
-                    instrument gains. It must be in HDF5 format. It must contain 
+                    instrument gains. It must be in HDF5 format. It must contain
                     the following structure:
-                    'antenna-based'     [dictionary] Contains antenna-based 
+                    'antenna-based'     [dictionary] Contains antenna-based
                                         instrument gain information. It has the
                                         following keys and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
+                                                    axes - 'time', 'label',
                                                     and 'frequency'. Must be
                                                     specified (no defaults)
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex antenna-based 
-                                                    instrument gains. Must be 
+                                        'gains'     [scalar or numpy array]
+                                                    Complex antenna-based
+                                                    instrument gains. Must be
                                                     of shape (nax1, nax2, nax3)
                                                     where ax1, ax2 and ax3 are
-                                                    specified by the axes 
-                                                    ordering under key 
-                                                    'ordering'. If there is no 
-                                                    variations in gains along an 
-                                                    axis, then the corresponding 
-                                                    nax may be set to 1 and the 
-                                                    gains will be replicated 
-                                                    along that axis using numpy 
-                                                    array broadcasting. For 
-                                                    example, shapes (nax1,1,1), 
+                                                    specified by the axes
+                                                    ordering under key
+                                                    'ordering'. If there is no
+                                                    variations in gains along an
+                                                    axis, then the corresponding
+                                                    nax may be set to 1 and the
+                                                    gains will be replicated
+                                                    along that axis using numpy
+                                                    array broadcasting. For
+                                                    example, shapes (nax1,1,1),
                                                     (1,1,1), (1,nax2,nax3) are
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy 
-                                                    array] List or antenna 
-                                                    labels that correspond to 
-                                                    the nax along the 'label' 
-                                                    axis. If the nax=1 along the 
-                                                    'label' axis, this may be 
-                                                    set to None, else it must be 
-                                                    specified and must match the 
-                                                    nax. 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the nax 
-                                                    along the 'frequency' axis. 
-                                                    If the nax=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nax. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the nax=1 along the 'time' 
-                                                    axis, this may be set to 
-                                                    None, else it must be 
-                                                    specified and must match the 
-                                                    nax. It must be a float and 
-                                                    can be in seconds, hours, 
+                                        'label'     [None or list or numpy
+                                                    array] List or antenna
+                                                    labels that correspond to
+                                                    the nax along the 'label'
+                                                    axis. If the nax=1 along the
+                                                    'label' axis, this may be
+                                                    set to None, else it must be
+                                                    specified and must match the
+                                                    nax.
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the nax
+                                                    along the 'frequency' axis.
+                                                    If the nax=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nax.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the nax=1 along the 'time'
+                                                    axis, this may be set to
+                                                    None, else it must be
+                                                    specified and must match the
+                                                    nax. It must be a float and
+                                                    can be in seconds, hours,
                                                     days, etc.
-                    'baseline-based'    [dictionary] Contains baseline-based 
+                    'baseline-based'    [dictionary] Contains baseline-based
                                         instrument gain information. It has the
                                         following keys and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
+                                                    axes - 'time', 'label',
                                                     and 'frequency'. Must be
                                                     specified (no defaults)
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex baseline-based 
-                                                    instrument gains. Must be 
+                                        'gains'     [scalar or numpy array]
+                                                    Complex baseline-based
+                                                    instrument gains. Must be
                                                     of shape (nax1, nax2, nax3)
                                                     where ax1, ax2 and ax3 are
-                                                    specified by the axes 
-                                                    ordering under key 
-                                                    'ordering'. If there is no 
-                                                    variations in gains along an 
-                                                    axis, then the corresponding 
-                                                    nax may be set to 1 and the 
-                                                    gains will be replicated 
-                                                    along that axis using numpy 
-                                                    array broadcasting. For 
-                                                    example, shapes (nax1,1,1), 
-                                                    (1,1,1), (1,nax2,nax3) are 
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    specified by the axes
+                                                    ordering under key
+                                                    'ordering'. If there is no
+                                                    variations in gains along an
+                                                    axis, then the corresponding
+                                                    nax may be set to 1 and the
+                                                    gains will be replicated
+                                                    along that axis using numpy
+                                                    array broadcasting. For
+                                                    example, shapes (nax1,1,1),
+                                                    (1,1,1), (1,nax2,nax3) are
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy 
-                                                    array] List of baseline 
-                                                    labels that correspond to 
-                                                    the nax along the 'label' 
-                                                    axis. If the nax=1 along the 
-                                                    'label' axis this may be set 
-                                                    to None, else it must be 
-                                                    specified and must match the 
-                                                    nax. 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the nax 
-                                                    along the 'frequency' axis. 
-                                                    If the nax=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nax. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the nax=1 along the 'time' 
-                                                    axis, this may be set to 
-                                                    None, else it must be 
-                                                    specified and must match the 
-                                                    nax. It must be a float and 
-                                                    can be in seconds, hours, 
+                                        'label'     [None or list or numpy
+                                                    array] List of baseline
+                                                    labels that correspond to
+                                                    the nax along the 'label'
+                                                    axis. If the nax=1 along the
+                                                    'label' axis this may be set
+                                                    to None, else it must be
+                                                    specified and must match the
+                                                    nax.
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the nax
+                                                    along the 'frequency' axis.
+                                                    If the nax=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nax.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the nax=1 along the 'time'
+                                                    axis, this may be set to
+                                                    None, else it must be
+                                                    specified and must match the
+                                                    nax. It must be a float and
+                                                    can be in seconds, hours,
                                                     days, etc.
-    
-        axes_order  [None or list or numpy array] The gaintable which is read is 
-                    stored in this axes ordering. If set to None, it will store 
+
+        axes_order  [None or list or numpy array] The gaintable which is read is
+                    stored in this axes ordering. If set to None, it will store
                     in this order ['label', 'frequency', 'time']
 
-        action      [string] If set to 'store' (default), the gain table will 
-                    be stored as attribute in addition to being returned. If set 
+        action      [string] If set to 'store' (default), the gain table will
+                    be stored as attribute in addition to being returned. If set
                     to 'return' the gain table will be returned.
-    
+
         Output:
-    
-        gaintable   [None or dictionary] If set to None, all antenna- and 
-                    baseline-based gains will be set to unity. If returned as 
-                    dictionary, it contains the loaded gains. It contains the 
+
+        gaintable   [None or dictionary] If set to None, all antenna- and
+                    baseline-based gains will be set to unity. If returned as
+                    dictionary, it contains the loaded gains. It contains the
                     following keys and values:
                     'antenna-based'     [None or dictionary] Contains antenna-
-                                        based instrument gain information. If 
-                                        set to None, all antenna-based gains are 
-                                        set to unity. If returned as dictionary, 
+                                        based instrument gain information. If
+                                        set to None, all antenna-based gains are
+                                        set to unity. If returned as dictionary,
                                         it has the following keys and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
+                                                    axes - 'time', 'label',
                                                     and 'frequency' as specified
                                                     in input axes_order
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex antenna-based 
-                                                    instrument gains. Must be 
+                                        'gains'     [scalar or numpy array]
+                                                    Complex antenna-based
+                                                    instrument gains. Must be
                                                     of shape (nant, nchan, nts)
-                                                    If there is no variations in 
-                                                    gains along an axis, then 
-                                                    the corresponding nax may be 
-                                                    set to 1 and the gains will 
-                                                    be replicated along that 
-                                                    axis using numpy array 
-                                                    broadcasting. For example, 
-                                                    shapes (nant,1,1), (1,1,1), 
-                                                    (1,nchan,nts) are 
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    If there is no variations in
+                                                    gains along an axis, then
+                                                    the corresponding nax may be
+                                                    set to 1 and the gains will
+                                                    be replicated along that
+                                                    axis using numpy array
+                                                    broadcasting. For example,
+                                                    shapes (nant,1,1), (1,1,1),
+                                                    (1,nchan,nts) are
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy 
-                                                    array] List or antenna 
-                                                    labels that correspond to 
-                                                    nant along the 'label' axis. 
-                                                    If nant=1, this may be set 
-                                                    to None, else it will be 
-                                                    specified and will match the 
-                                                    nant. 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the nax 
-                                                    along the 'frequency' axis. 
-                                                    If the nchan=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nchan. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the ntimes=1 along the 
-                                                    'time' axis, this may be set 
-                                                    to None, else it must be 
-                                                    specified and must match the 
-                                                    ntimes. It will be a float 
-                                                    and in same units as given 
+                                        'label'     [None or list or numpy
+                                                    array] List or antenna
+                                                    labels that correspond to
+                                                    nant along the 'label' axis.
+                                                    If nant=1, this may be set
+                                                    to None, else it will be
+                                                    specified and will match the
+                                                    nant.
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the nax
+                                                    along the 'frequency' axis.
+                                                    If the nchan=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nchan.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the ntimes=1 along the
+                                                    'time' axis, this may be set
+                                                    to None, else it must be
+                                                    specified and must match the
+                                                    ntimes. It will be a float
+                                                    and in same units as given
                                                     in input
                     'baseline-based'    [None or dictionary] Contains baseline-
-                                        based instrument gain information. If 
-                                        set to None, all baseline-based gains 
-                                        are set to unity. If returned as 
-                                        dictionary, it has the following keys 
+                                        based instrument gain information. If
+                                        set to None, all baseline-based gains
+                                        are set to unity. If returned as
+                                        dictionary, it has the following keys
                                         and values:
                                         'ordering'  [list or numpy array] Three
-                                                    element list of strings 
+                                                    element list of strings
                                                     indicating the ordering of
-                                                    axes - 'time', 'label', 
-                                                    and 'frequency' as 
-                                                    specified in input 
-                                                    axes_order 
-                                        'gains'     [scalar or numpy array] 
-                                                    Complex baseline-based 
-                                                    instrument gains. Must be 
+                                                    axes - 'time', 'label',
+                                                    and 'frequency' as
+                                                    specified in input
+                                                    axes_order
+                                        'gains'     [scalar or numpy array]
+                                                    Complex baseline-based
+                                                    instrument gains. Must be
                                                     of shape (nbl, nchan, nts)
-                                                    If there is no variations in 
-                                                    gains along an axis, then 
-                                                    the corresponding nax may be 
-                                                    set to 1 and the gains will 
-                                                    be replicated along that 
-                                                    axis using numpy array 
-                                                    broadcasting. For example, 
-                                                    shapes (nant,1,1), (1,1,1), 
-                                                    (1,nchan,nts) are 
-                                                    acceptable. If specified as 
-                                                    a scalar, it will be 
-                                                    replicated along all three 
-                                                    axes, namely, 'label', 
+                                                    If there is no variations in
+                                                    gains along an axis, then
+                                                    the corresponding nax may be
+                                                    set to 1 and the gains will
+                                                    be replicated along that
+                                                    axis using numpy array
+                                                    broadcasting. For example,
+                                                    shapes (nant,1,1), (1,1,1),
+                                                    (1,nchan,nts) are
+                                                    acceptable. If specified as
+                                                    a scalar, it will be
+                                                    replicated along all three
+                                                    axes, namely, 'label',
                                                     'frequency' and 'time'.
-                                        'label'     [None or list or numpy 
-                                                    array] List or baseline 
-                                                    labels that correspond to 
-                                                    nbl along the 'label' axis. 
-                                                    If nbl=1 along the 'label' 
-                                                    axis this may be set to 
-                                                    None, else it will be 
-                                                    specified and will match nbl 
-                                        'frequency' [None or list or numpy 
-                                                    array] Frequency channels 
-                                                    that correspond to the nax 
-                                                    along the 'frequency' axis. 
-                                                    If the nchan=1 along the 
-                                                    'frequency' axis, this may 
-                                                    be set to None, else it must 
-                                                    be specified and must match 
-                                                    the nchan. 
-                                        'time'      [None or list or numpy 
-                                                    array] Observation times 
-                                                    that correspond to the nax 
-                                                    along the 'time' axis. If 
-                                                    the ntimes=1 along the 
-                                                    'time' axis, this may be set 
-                                                    to None, else it must be 
-                                                    specified and must match the 
-                                                    ntimes. It will be a float 
-                                                    and in same units as given 
+                                        'label'     [None or list or numpy
+                                                    array] List or baseline
+                                                    labels that correspond to
+                                                    nbl along the 'label' axis.
+                                                    If nbl=1 along the 'label'
+                                                    axis this may be set to
+                                                    None, else it will be
+                                                    specified and will match nbl
+                                        'frequency' [None or list or numpy
+                                                    array] Frequency channels
+                                                    that correspond to the nax
+                                                    along the 'frequency' axis.
+                                                    If the nchan=1 along the
+                                                    'frequency' axis, this may
+                                                    be set to None, else it must
+                                                    be specified and must match
+                                                    the nchan.
+                                        'time'      [None or list or numpy
+                                                    array] Observation times
+                                                    that correspond to the nax
+                                                    along the 'time' axis. If
+                                                    the ntimes=1 along the
+                                                    'time' axis, this may be set
+                                                    to None, else it must be
+                                                    specified and must match the
+                                                    ntimes. It will be a float
+                                                    and in same units as given
                                                     in input
         ------------------------------------------------------------------------
         """
@@ -2094,9 +2094,9 @@ class GainInfo(object):
         ------------------------------------------------------------------------
         Sets up interpolation functions and stores them in the attribute
         interpfuncs. Better alternative is to use splinator()
-        
+
         Inputs:
-        
+
         kind    [string] Type of interpolation. Accepted values are
                 'linear' (default), 'cubic' or 'quintic'. See documentation
                 of scipy.interpolate.interp1d and scipy.interpolate.interp2d
@@ -2140,7 +2140,7 @@ class GainInfo(object):
                                         interpf_imag = interpolate.interp2d(self.gaintable[gainkey]['time'], self.gaintable[gainkey]['frequency'], gains[labelind,:,:].imag, kind=kind, bounds_error=True)
                                     interpf += [(copy.copy(interpf_real), copy.copy(interpf_imag))]
                                 self.interpfuncs[gainkey] = {'interp': NP.asarray(interpf, dtype=[('real', NP.object), ('imag', NP.object)]), 'dims': dims}
-                                        
+
     ############################################################################
 
     def splinator(self, smoothness=None):
@@ -2149,14 +2149,14 @@ class GainInfo(object):
         -----------------------------------------------------------------------
         Sets up spline functions and stores them in the attribute splinefuncs.
         Better alternative to interpolator()
-        
+
         Inputs:
-        
+
         smoothness  [integer or float] Smoothness of spline interpolation. Must
-                    be positive. If set to None (default), it will set equal to 
+                    be positive. If set to None (default), it will set equal to
                     the number of samples using which the spline functions are
-                    estimated. Read documentation of 
-                    scipy.interpolate.UnivariateSpline and 
+                    estimated. Read documentation of
+                    scipy.interpolate.UnivariateSpline and
                     scipy.interpolate.RectBivariateSpline for more details
         -----------------------------------------------------------------------
         """
@@ -2202,9 +2202,9 @@ class GainInfo(object):
                                         interpf_imag = interpolate.RectBivariateSpline(self.gaintable[gainkey]['time'], self.gaintable[gainkey]['frequency'], gains[labelind,:,:].imag.T, bbox=[self.gaintable[gainkey]['time'].min(), self.gaintable[gainkey]['time'].max(), self.gaintable[gainkey]['frequency'].min(), self.gaintable[gainkey]['frequency'].max()], s=smoothness)
                                     interpf += [(copy.copy(interpf_real), copy.copy(interpf_imag))]
                                 self.splinefuncs[gainkey] = {'interp': NP.asarray(interpf, dtype=[('real', NP.object), ('imag', NP.object)]), 'dims': dims}
-                                        
+
     #############################################################################
-    
+
     def interpolate_gains(self, bl_labels, freqs=None, times=None,
                           axes_order=None):
 
@@ -2213,40 +2213,40 @@ class GainInfo(object):
         Interpolate at the specified baselines for the given frequencies and
         times using attribute interpfuncs. Better alternative is to use
         spline_gains()
-        
+
         Inputs:
-        
-        bl_labels   [Numpy structured array tuples] Labels of antennas in the 
-                    pair used to produce the baseline vector under fields 'A2' 
-                    and 'A1' for second and first antenna respectively. The 
-                    baseline vector is obtained by position of antennas under 
-                    'A2' minus position of antennas under 'A1'. The array is of 
+
+        bl_labels   [Numpy structured array tuples] Labels of antennas in the
+                    pair used to produce the baseline vector under fields 'A2'
+                    and 'A1' for second and first antenna respectively. The
+                    baseline vector is obtained by position of antennas under
+                    'A2' minus position of antennas under 'A1'. The array is of
                     size nbl
-        
-        freqs       [None or numpy array] Array of frequencies at which the 
-                    gains are to be interpolated using the attribute 
-                    interpfuncs. If set to None (default), all frequencies in 
-                    the gaintable are assumed. The specified frequencies must 
-                    always lie within the range which was used in creating the 
-                    interpolation functions, otherwise an exception will be 
+
+        freqs       [None or numpy array] Array of frequencies at which the
+                    gains are to be interpolated using the attribute
+                    interpfuncs. If set to None (default), all frequencies in
+                    the gaintable are assumed. The specified frequencies must
+                    always lie within the range which was used in creating the
+                    interpolation functions, otherwise an exception will be
                     raised. The array is of size nchan
-        
+
         times       [None or numpy array] Array of times at which the gains
-                    are to be interpolated using the attribute interpfuncs. If 
+                    are to be interpolated using the attribute interpfuncs. If
                     set to None (default), all times in the gaintable are
                     assumed. The specified times must always lie within the
-                    range which was used in creating the interpolation 
-                    functions, otherwise an exception will be raised. The 
+                    range which was used in creating the interpolation
+                    functions, otherwise an exception will be raised. The
                     array is of size nts
-        
-        axes_order  [None or list or numpy array] Axes ordering for extracted 
-                    gains. It must contain the three elements 'label', 
-                    'frequency', and 'time'. If set to None, it will be 
+
+        axes_order  [None or list or numpy array] Axes ordering for extracted
+                    gains. It must contain the three elements 'label',
+                    'frequency', and 'time'. If set to None, it will be
                     returned in the same order as in the input gaintable.
-        
+
         Outputs:
-        
-        [numpy array] Complex gains of shape nbl x nchan x nts for the 
+
+        [numpy array] Complex gains of shape nbl x nchan x nts for the
         specified baselines, frequencies and times.
         ------------------------------------------------------------------------
         """
@@ -2338,7 +2338,7 @@ class GainInfo(object):
                             inp_freqs = freqs[ib_freq_index]
                             ntimes = ib_time_index.size
                             nchan = ib_freq_index.size
-                                
+
                         if key == 'antenna-based':
                             ind1 = NMO.find_list_in_list(labels, a1_labels)
                             ind2 = NMO.find_list_in_list(labels, a2_labels)
@@ -2363,7 +2363,7 @@ class GainInfo(object):
                                     else:
                                         g1_conj = NP.concatenate((g1_conj, (self.interpfuncs[key]['interp']['real'][ind1[i]](inp_times,inp_freqs) - 1j * self.interpfuncs[key]['interp']['imag'][ind1[i]](inp_times,inp_freqs)).reshape(1,nchan,ntimes)), axis=0)
                                         g2 = NP.concatenate((g2, (self.interpfuncs[key]['interp']['real'][ind2[i]](inp_times,inp_freqs) + 1j * self.interpfuncs[key]['interp']['imag'][ind2[i]](inp_times,inp_freqs)).reshape(1,nchan,ntimes)), axis=0)
-                                    
+
                             blgains = blgains * g1_conj * g2 * NP.ones((1,nchan,ntimes), dtype=NP.complex)
                         else:
                             g12 = None
@@ -2415,50 +2415,50 @@ class GainInfo(object):
         blgains = NP.transpose(blgains, axes=transpose_order)
 
         return blgains
-                                        
+
     #############################################################################
-    
+
     def spline_gains(self, bl_labels, freqs=None, times=None, axes_order=None):
 
         """
         ------------------------------------------------------------------------
         Evaluate spline at the specified baselines for the given frequencies and
-        times using attribute splinefuncs. Better alternative to 
+        times using attribute splinefuncs. Better alternative to
         interpolate_gains()
-        
+
         Inputs:
-        
-        bl_labels   [Numpy structured array tuples] Labels of antennas in the 
-                    pair used to produce the baseline vector under fields 'A2' 
-                    and 'A1' for second and first antenna respectively. The 
-                    baseline vector is obtained by position of antennas under 
-                    'A2' minus position of antennas under 'A1'. The array is of 
+
+        bl_labels   [Numpy structured array tuples] Labels of antennas in the
+                    pair used to produce the baseline vector under fields 'A2'
+                    and 'A1' for second and first antenna respectively. The
+                    baseline vector is obtained by position of antennas under
+                    'A2' minus position of antennas under 'A1'. The array is of
                     size nbl
-        
-        freqs       [None or numpy array] Array of frequencies at which the 
-                    gains are to be interpolated using the attribute 
-                    splinefuncs. If set to None (default), all frequencies in 
-                    the gaintable are assumed. The specified frequencies must 
-                    always lie within the range which was used in creating the 
-                    interpolation functions, otherwise an exception will be 
+
+        freqs       [None or numpy array] Array of frequencies at which the
+                    gains are to be interpolated using the attribute
+                    splinefuncs. If set to None (default), all frequencies in
+                    the gaintable are assumed. The specified frequencies must
+                    always lie within the range which was used in creating the
+                    interpolation functions, otherwise an exception will be
                     raised. The array is of size nchan
-        
+
         times       [None or numpy array] Array of times at which the gains
-                    are to be interpolated using the attribute splinefuncs. If 
+                    are to be interpolated using the attribute splinefuncs. If
                     set to None (default), all times in the gaintable are
                     assumed. The specified times must always lie within the
-                    range which was used in creating the interpolation 
-                    functions, otherwise an exception will be raised. The array 
+                    range which was used in creating the interpolation
+                    functions, otherwise an exception will be raised. The array
                     is of size nts
-        
-        axes_order  [None or list or numpy array] Axes ordering for extracted 
-                    gains. It must contain the three elements 'label', 
-                    'frequency', and 'time'. If set to None, it will be 
+
+        axes_order  [None or list or numpy array] Axes ordering for extracted
+                    gains. It must contain the three elements 'label',
+                    'frequency', and 'time'. If set to None, it will be
                     returned in the same order as in the input gaintable.
-        
+
         Outputs:
-        
-        [numpy array] Complex gains of shape nbl x nchan x nts for the specified 
+
+        [numpy array] Complex gains of shape nbl x nchan x nts for the specified
         baselines, frequencies and times.
         ---------------------------------------------------------------------------
         """
@@ -2551,7 +2551,7 @@ class GainInfo(object):
                             inp_freqs = freqs[ib_freq_index]
                             ntimes = ib_time_index.size
                             nchan = ib_freq_index.size
-                                
+
                         tgrid, fgrid = NP.meshgrid(inp_times, inp_freqs)
                         tvec = tgrid.ravel()
                         fvec = fgrid.ravel()
@@ -2580,7 +2580,7 @@ class GainInfo(object):
                                     else:
                                         g1_conj = NP.concatenate((g1_conj, (self.splinefuncs[key]['interp']['real'][ind1[i]].ev(tvec,fvec) - 1j * self.splinefuncs[key]['interp']['imag'][ind1[i]].ev(tvec,fvec)).reshape(1,nchan,ntimes)), axis=0)
                                         g2 = NP.concatenate((g2, (self.splinefuncs[key]['interp']['real'][ind2[i]].ev(tvec,fvec) + 1j * self.splinefuncs[key]['interp']['imag'][ind2[i]].ev(tvec,fvec)).reshape(1,nchan,ntimes)), axis=0)
-                                    
+
                             blgains = blgains * g1_conj * g2 * NP.ones((1,nchan,ntimes), dtype=NP.complex)
                         else:
                             g12 = None
@@ -2632,48 +2632,48 @@ class GainInfo(object):
         blgains = NP.transpose(blgains, axes=transpose_order)
 
         return blgains
-                                        
+
     #############################################################################
-    
+
     def nearest_gains(self, bl_labels, freqs=None, times=None, axes_order=None):
 
         """
         ------------------------------------------------------------------------
         Extract complex instrument gains for given baselines from the gain table
         determined by nearest neighbor logic
-    
+
         Inputs:
-    
-        bl_labels   [Numpy structured array tuples] Labels of antennas in the 
-                    pair used to produce the baseline vector under fields 'A2' 
-                    and 'A1' for second and first antenna respectively. The 
-                    baseline vector is obtained by position of antennas under 
+
+        bl_labels   [Numpy structured array tuples] Labels of antennas in the
+                    pair used to produce the baseline vector under fields 'A2'
+                    and 'A1' for second and first antenna respectively. The
+                    baseline vector is obtained by position of antennas under
                     'A2' minus position of antennas under 'A1'
-    
-        freqs       [None or numpy array] Array of frequencies at which the 
-                    gains are to be interpolated using the attribute 
-                    splinefuncs. If set to None (default), all frequencies in 
-                    the gaintable are assumed. The specified frequencies must 
-                    always lie within the range which was used in creating the 
-                    interpolation functions, otherwise an exception will be 
+
+        freqs       [None or numpy array] Array of frequencies at which the
+                    gains are to be interpolated using the attribute
+                    splinefuncs. If set to None (default), all frequencies in
+                    the gaintable are assumed. The specified frequencies must
+                    always lie within the range which was used in creating the
+                    interpolation functions, otherwise an exception will be
                     raised. The array is of size nchan
-        
+
         times       [None or numpy array] Array of times at which the gains
-                    are to be interpolated using the attribute splinefuncs. If 
+                    are to be interpolated using the attribute splinefuncs. If
                     set to None (default), all times in the gaintable are
                     assumed. The specified times must always lie within the
-                    range which was used in creating the interpolation 
-                    functions, otherwise an exception will be raised. The array 
+                    range which was used in creating the interpolation
+                    functions, otherwise an exception will be raised. The array
                     is of size nts
-        
-        axes_order  [None or list or numpy array] Axes ordering for extracted 
-                    gains. It must contain the three elements 'label', 
-                    'frequency', and 'time'. If set to None, it will be 
-                    returned in the same order as in the input gaintable. 
-    
-        Outputs: 
-    
-        [numpy array] Complex gains of shape nbl x nchan x nts for the specified 
+
+        axes_order  [None or list or numpy array] Axes ordering for extracted
+                    gains. It must contain the three elements 'label',
+                    'frequency', and 'time'. If set to None, it will be
+                    returned in the same order as in the input gaintable.
+
+        Outputs:
+
+        [numpy array] Complex gains of shape nbl x nchan x nts for the specified
         baselines, frequencies and times.
         ------------------------------------------------------------------------
         """
@@ -2696,11 +2696,11 @@ class GainInfo(object):
                         gains = NP.copy(self.gaintable[gainkey]['gains'])
                     else:
                         gains = NP.transpose(NP.copy(self.gaintable[gainkey]['gains']), axes=temp_transpose_order)
-    
+
                     freqs_to_search = copy.copy(freqs)
                     if freqs_to_search is None:
                         freqs_to_search = copy.copy(self.gaintable[gainkey]['frequency'])
-                        
+
                     if freqs_to_search is not None:
                         if self.gaintable[gainkey]['frequency'] is not None:
                             inpind, refind_freqs, distNN= LKP.find_1NN(self.gaintable[gainkey]['frequency'].reshape(-1,1), freqs_to_search.reshape(-1,1), remove_oob=True)
@@ -2708,11 +2708,11 @@ class GainInfo(object):
                             refind_freqs = None
                     if refind_freqs is None:
                         refind_freqs = NP.arange(gains.shape[1])
-    
+
                     times_to_search = copy.copy(times)
                     if times_to_search is None:
                         times_to_search = copy.copy(self.gaintable[gainkey]['time'])
-                        
+
                     if times_to_search is not None:
                         if self.gaintable[gainkey]['time'] is not None:
                             inpind, refind_times, distNN = LKP.find_1NN(self.gaintable[gainkey]['time'].reshape(-1,1), times_to_search.reshape(-1,1), remove_oob=True)
@@ -2720,7 +2720,7 @@ class GainInfo(object):
                             refind_times = None
                     if refind_times is None:
                         refind_times = NP.arange(gains.shape[2])
-    
+
                     if gains.shape[0] == 1:
                         blgains = blgains * gains[:,refind_freqs,refind_times].reshape(1,refind_freqs.size,refind_times.size)
                     else:
@@ -2753,10 +2753,10 @@ class GainInfo(object):
                         for orderkey in ['label', 'frequency', 'time']:
                             if orderkey not in axes_order:
                                 raise ValueError('axes_order does not contain key "{0}"'.format(orderkey))
-    
+
                     transpose_order = NMO.find_list_in_list(inp_order, axes_order)
                     blgains = NP.transpose(blgains, axes=transpose_order)
-    
+
         return blgains
 
     #############################################################################
@@ -2766,34 +2766,34 @@ class GainInfo(object):
 
         """
         ------------------------------------------------------------------------
-        Extract complex instrument gains for given baselines from the gain table 
-    
+        Extract complex instrument gains for given baselines from the gain table
+
         Inputs:
-    
-        bl_labels   [Numpy structured array tuples] Labels of antennas in the 
-                    pair used to produce the baseline vector under fields 'A2' 
-                    and 'A1' for second and first antenna respectively. The 
-                    baseline vector is obtained by position of antennas under 
+
+        bl_labels   [Numpy structured array tuples] Labels of antennas in the
+                    pair used to produce the baseline vector under fields 'A2'
+                    and 'A1' for second and first antenna respectively. The
+                    baseline vector is obtained by position of antennas under
                     'A2' minus position of antennas under 'A1'
-    
-        freq_index  [None, int, list or numpy array] Index (scalar) or indices 
-                    (list or numpy array) along the frequency axis at which 
-                    gains are to be extracted. If set to None, gains at all 
-                    frequencies in the gain table will be extracted. 
-    
-        time_index  [None, int, list or numpy array] Index (scalar) or indices 
-                    (list or numpy array) along the time axis at which gains 
-                    are to be extracted. If set to None, gains at all timesin 
-                    the gain table will be extracted. 
-    
-        axes_order  [None or list or numpy array] Axes ordering for extracted 
-                    gains. It must contain the three elements 'label', 
-                    'frequency', and 'time'. If set to None, it will be 
-                    returned in the same order as in the input gaintable. 
-    
-        Outputs: 
-    
-        [numpy array] Complex gains of shape nbl x nchan x nts for the specified 
+
+        freq_index  [None, int, list or numpy array] Index (scalar) or indices
+                    (list or numpy array) along the frequency axis at which
+                    gains are to be extracted. If set to None, gains at all
+                    frequencies in the gain table will be extracted.
+
+        time_index  [None, int, list or numpy array] Index (scalar) or indices
+                    (list or numpy array) along the time axis at which gains
+                    are to be extracted. If set to None, gains at all timesin
+                    the gain table will be extracted.
+
+        axes_order  [None or list or numpy array] Axes ordering for extracted
+                    gains. It must contain the three elements 'label',
+                    'frequency', and 'time'. If set to None, it will be
+                    returned in the same order as in the input gaintable.
+
+        Outputs:
+
+        [numpy array] Complex gains of shape nbl x nchan x nts for the specified
         baselines, frequencies and times.
         ------------------------------------------------------------------------
         """
@@ -2808,7 +2808,7 @@ class GainInfo(object):
 
         """
         ------------------------------------------------------------------------
-        Write gain table with specified axes ordering to external file in HDF5 
+        Write gain table with specified axes ordering to external file in HDF5
         format
 
         Inputs:
@@ -2816,19 +2816,19 @@ class GainInfo(object):
         outfile     [string] Filename including full path into which the gain
                     table will be written
 
-        axes_order  [None or list or numpy array] The axes ordering of gain 
-                    table that will be written to external file specified in 
+        axes_order  [None or list or numpy array] The axes ordering of gain
+                    table that will be written to external file specified in
                     outfile. If set to None, it will store in the same order
                     as in the attribute gaintable
-        
-        compress    [boolean] Specifies if the gain table is written in 
+
+        compress    [boolean] Specifies if the gain table is written in
                     compressed format. The compression format and compression
                     parameters are specified in compress_fmt and compress_opts
                     respectively
 
-        compress_fmt 
+        compress_fmt
                     [string] Accepted values are 'gzip' (default) or 'lzf'. See
-                    h5py module documentation for comparison of these 
+                    h5py module documentation for comparison of these
                     compression formats
 
         compress_opts
@@ -2837,7 +2837,7 @@ class GainInfo(object):
                     maximum compression
         ------------------------------------------------------------------------
         """
-        
+
         try:
             outfile
         except NameError:
@@ -2878,7 +2878,7 @@ class GainInfo(object):
                         gains = NP.copy(self.gaintable[gainkey]['gains'])
                     else:
                         gains = NP.transpose(NP.copy(self.gaintable[gainkey]['gains']), axes=transpose_order)
-                    
+
                     grp = fileobj.create_group(gainkey)
                     for subkey in self.gaintable[gainkey]:
                         if subkey == 'gains':
@@ -2928,53 +2928,53 @@ class ROI_parameters(object):
                 determined. It specifies the type of element, element size and
                 orientation. It consists of the following keys and information:
                 'id'          [string] If set, will ignore the other keys and use
-                              telescope details for known telescopes. Accepted 
-                              values are 'mwa', 'vla', 'gmrt', 'hera', 'paper', 
-                              'hirax', 'chime' and 'mwa_tools'. If using 
-                              'mwa_tools', the MWA_Tools and mwapb modules must 
-                              be installed and imported.  
+                              telescope details for known telescopes. Accepted
+                              values are 'mwa', 'vla', 'gmrt', 'hera', 'paper',
+                              'hirax', 'chime' and 'mwa_tools'. If using
+                              'mwa_tools', the MWA_Tools and mwapb modules must
+                              be installed and imported.
                 'shape'       [string] Shape of antenna element. Accepted values
-                              are 'dipole', 'delta', and 'dish'. Will be ignored 
+                              are 'dipole', 'delta', and 'dish'. Will be ignored
                               if key 'id' is set. 'delta' denotes a delta
                               function for the antenna element which has an
                               isotropic radiation pattern. 'delta' is the default
                               when keys 'id' and 'shape' are not set.
-                'size'        [scalar] Diameter of the telescope dish (in meters) 
-                              if the key 'shape' is set to 'dish' or length of 
-                              the dipole if key 'shape' is set to 'dipole'. Will 
-                              be ignored if key 'shape' is set to 'delta'. Will 
-                              be ignored if key 'id' is set and a preset value 
+                'size'        [scalar] Diameter of the telescope dish (in meters)
+                              if the key 'shape' is set to 'dish' or length of
+                              the dipole if key 'shape' is set to 'dipole'. Will
+                              be ignored if key 'shape' is set to 'delta'. Will
+                              be ignored if key 'id' is set and a preset value
                               used for the diameter or dipole.
-                'orientation' [list or numpy array] If key 'shape' is set to 
-                              dipole, it refers to the orientation of the dipole 
-                              element unit vector whose magnitude is specified by 
-                              length. If key 'shape' is set to 'dish', it refers 
+                'orientation' [list or numpy array] If key 'shape' is set to
+                              dipole, it refers to the orientation of the dipole
+                              element unit vector whose magnitude is specified by
+                              length. If key 'shape' is set to 'dish', it refers
                               to the position on the sky to which the dish is
                               pointed. For a dipole, this unit vector must be
-                              provided in the local ENU coordinate system aligned 
+                              provided in the local ENU coordinate system aligned
                               with the direction cosines coordinate system or in
                               the Alt-Az coordinate system. This will be
                               used only when key 'shape' is set to 'dipole'.
-                              This could be a 2-element vector (transverse 
-                              direction cosines) where the third (line-of-sight) 
+                              This could be a 2-element vector (transverse
+                              direction cosines) where the third (line-of-sight)
                               component is determined, or a 3-element vector
                               specifying all three direction cosines or a two-
-                              element coordinate in Alt-Az system. If not provided 
+                              element coordinate in Alt-Az system. If not provided
                               it defaults to an eastward pointing dipole. If key
-                              'shape' is set to 'dish', the orientation refers 
+                              'shape' is set to 'dish', the orientation refers
                               to the pointing center of the dish on the sky. It
                               can be provided in Alt-Az system as a two-element
                               vector or in the direction cosine coordinate
                               system as a two- or three-element vector. If not
-                              set in the case of a dish element, it defaults to 
+                              set in the case of a dish element, it defaults to
                               zenith. This is not to be confused with the key
-                              'pointing_center' in dictionary 'pointing_info' 
+                              'pointing_center' in dictionary 'pointing_info'
                               which refers to the beamformed pointing center of
-                              the array. The coordinate system is specified by 
+                              the array. The coordinate system is specified by
                               the key 'ocoords'
-                'ocoords'     [scalar string] specifies the coordinate system 
+                'ocoords'     [scalar string] specifies the coordinate system
                               for key 'orientation'. Accepted values are 'altaz'
-                              and 'dircos'. 
+                              and 'dircos'.
                 'element_locs'
                               [2- or 3-column array] Element locations that
                               constitute the tile. Each row specifies
@@ -2982,26 +2982,26 @@ class ROI_parameters(object):
                               locations must be specified in local ENU
                               coordinate system. First column specifies along
                               local east, second along local north and the
-                              third along local up. If only two columns are 
-                              specified, the third column is assumed to be 
+                              third along local up. If only two columns are
+                              specified, the third column is assumed to be
                               zeros. If 'elements_locs' is not provided, it
                               assumed to be a one-element system and not a
-                              phased array as far as determination of primary 
+                              phased array as far as determination of primary
                               beam is concerned.
-                'groundplane' [scalar] height of telescope element above the 
+                'groundplane' [scalar] height of telescope element above the
                               ground plane (in meteres). Default = None will
                               denote no ground plane effects.
                 'ground_modify'
                               [dictionary] contains specifications to modify
                               the analytically computed ground plane pattern. If
                               absent, the ground plane computed will not be
-                              modified. If set, it may contain the following 
+                              modified. If set, it may contain the following
                               keys:
-                              'scale' [scalar] positive value to scale the 
-                                      modifying factor with. If not set, the 
+                              'scale' [scalar] positive value to scale the
+                                      modifying factor with. If not set, the
                                       scale factor to the modification is unity.
-                              'max'   [scalar] positive value to clip the 
-                                      modified and scaled values to. If not set, 
+                              'max'   [scalar] positive value to clip the
+                                      modified and scaled values to. If not set,
                                       there is no upper limit
                 'latitude'    [scalar] specifies latitude of the telescope site
                               (in degrees). Default = None (advisable to specify
@@ -3011,7 +3011,7 @@ class ROI_parameters(object):
                 'altitude'    [scalar] Specifies altitude of the telescope site
                               (in m) above the surface of the Earth. Default=0m
                 'pol'         [string] specifies polarization when using
-                              MWA_Tools for primary beam computation. Value of 
+                              MWA_Tools for primary beam computation. Value of
                               key 'id' in attribute dictionary telescope must be
                               set to 'mwa_tools'. 'X' or 'x' denotes
                               X-polarization. Y-polarization is specified by 'Y'
@@ -3023,43 +3023,43 @@ class ROI_parameters(object):
                 It consists of the following keys and information:
                 'radius'  [list of scalars] list of angular radii (in degrees),
                           one entry for each snapshot observation which defines
-                          the region of interest. 
+                          the region of interest.
                 'center'  [list of numpy vectors] list of centers of regions of
                           interest. For each snapshot, there is one element in
                           the list each of which is a center of corresponding
                           region of interest. Each numpy vector could be made of
-                          two elements (Alt-Az) or three elements (direction 
+                          two elements (Alt-Az) or three elements (direction
                           cosines).
                 'ind'     [list of numpy vectors] list of vectors of indices
                           that define the region of interest as a subset of the
                           sky model. Each element of the list is a numpy vector
                           of indices indexing into the sky model corresponding
-                          to each snapshot. 
+                          to each snapshot.
                 'pbeam'   [list of numpy arrays] list of array of primary beam
                           values in the region of interest. The size of each
                           element in the list corresponding to each snapshot is
-                          n_roi x nchan where n_roi is the number of pixels in 
-                          region of interest. 
-    
+                          n_roi x nchan where n_roi is the number of pixels in
+                          region of interest.
+
     pinfo       [list of dictionaries] Each dictionary element in the list
                 corresponds to a specific snapshot. It contains information
-                relating to the pointing center. The pointing center can be 
-                specified either via element delay compensation or by directly 
-                specifying the pointing center in a certain coordinate system. 
-                Default = None (pointing centered at zenith). Each dictionary 
+                relating to the pointing center. The pointing center can be
+                specified either via element delay compensation or by directly
+                specifying the pointing center in a certain coordinate system.
+                Default = None (pointing centered at zenith). Each dictionary
                 element may consist of the following keys and information:
-                'gains'           [numpy array] Complex element gains. Must be of 
-                                  size equal to the number of elements as 
-                                  specified by the number of rows in 
-                                  'element_locs'. If set to None (default), all 
-                                  element gains are assumed to be unity. 
-                'delays'          [numpy array] Delays (in seconds) to be applied 
-                                  to the tile elements. Size should be equal to 
+                'gains'           [numpy array] Complex element gains. Must be of
+                                  size equal to the number of elements as
+                                  specified by the number of rows in
+                                  'element_locs'. If set to None (default), all
+                                  element gains are assumed to be unity.
+                'delays'          [numpy array] Delays (in seconds) to be applied
+                                  to the tile elements. Size should be equal to
                                   number of tile elements (number of rows in
                                   antpos). Default = None will set all element
-                                  delays to zero phasing them to zenith. 
-                'pointing_center' [numpy array] This will apply in the absence of 
-                                  key 'delays'. This can be specified as a row 
+                                  delays to zero phasing them to zenith.
+                'pointing_center' [numpy array] This will apply in the absence of
+                                  key 'delays'. This can be specified as a row
                                   vector. Should have two-columns if using Alt-Az
                                   coordinates, or two or three columns if using
                                   direction cosines. There is no default. The
@@ -3067,20 +3067,20 @@ class ROI_parameters(object):
                                   'pointing_coords' if 'pointing_center' is to be
                                   used.
                 'pointing_coords' [string scalar] Coordinate system in which the
-                                  pointing_center is specified. Accepted values 
+                                  pointing_center is specified. Accepted values
                                   are 'altaz' or 'dircos'. Must be provided if
                                   'pointing_center' is to be used. No default.
                 'delayerr'        [int, float] RMS jitter in delays used in the
-                                  beamformer. Random jitters are drawn from a 
+                                  beamformer. Random jitters are drawn from a
                                   normal distribution with this rms. Must be
                                   a non-negative scalar. If not provided, it
-                                  defaults to 0 (no jitter). 
-    
+                                  defaults to 0 (no jitter).
+
     Member functions:
 
-    __init__()  Initializes an instance of class ROI_parameters using default 
+    __init__()  Initializes an instance of class ROI_parameters using default
                 values or using a specified initialization file
-    
+
     append_settings()
                 Determines and appends ROI (regions of interest) parameter
                 information for each snapshot observation using the input
@@ -3108,7 +3108,7 @@ class ROI_parameters(object):
         Keyword input(s):
 
         init_file    [string] Location of the initialization file from which an
-                     instance of class ROI_parameters will be created. File 
+                     instance of class ROI_parameters will be created. File
                      format must be compatible with the one saved to disk by
                      member function save()
         -------------------------------------------------------------------------
@@ -3149,7 +3149,7 @@ class ROI_parameters(object):
                     self.telescope['altitude'] = hdulist[0].header['altitude']
                 else:
                     self.telescope['altitude'] = 0.0
-                    
+
                 try:
                     self.telescope['shape'] = hdulist[0].header['element_shape']
                 except KeyError:
@@ -3164,7 +3164,7 @@ class ROI_parameters(object):
                     self.telescope['ocoords'] = hdulist[0].header['element_ocoords']
                 except KeyError:
                     raise KeyError('Antenna element orientation coordinate system not found in the init_file header')
-                    
+
                 if 'ANTENNA ELEMENT ORIENTATION' in extnames:
                     self.telescope['orientation'] = hdulist['ANTENNA ELEMENT ORIENTATION'].data.reshape(1,-1)
                 else:
@@ -3213,7 +3213,7 @@ class ROI_parameters(object):
                                 self.pinfo[-1]['delayerr'] = None
                             else:
                                 self.pinfo[-1]['delayerr'] = delayerr
-    
+
                 len_pinfo = len(self.pinfo)
                 if len_pinfo > 0:
                     if len_pinfo != n_obs:
@@ -3278,93 +3278,93 @@ class ROI_parameters(object):
 
         pinfo    [list of dictionaries] Each dictionary element in the list
                  corresponds to a specific snapshot. It contains information
-                 relating to the pointing center. The pointing center can be 
-                 specified either via element delay compensation or by directly 
-                 specifying the pointing center in a certain coordinate system. 
-                 Default = None (pointing centered at zenith). Each dictionary 
+                 relating to the pointing center. The pointing center can be
+                 specified either via element delay compensation or by directly
+                 specifying the pointing center in a certain coordinate system.
+                 Default = None (pointing centered at zenith). Each dictionary
                  element may consist of the following keys and information:
-                 'gains'           [numpy array] Complex element gains. Must be 
-                                   of size equal to the number of elements as 
-                                   specified by the number of rows in 
-                                   'element_locs'. If set to None (default), all 
-                                   element gains are assumed to be unity. 
-                 'delays'          [numpy array] Delays (in seconds) to be 
-                                   applied to the tile elements. Size should be 
-                                   equal to number of tile elements (number of 
-                                   rows in antpos). Default = None will set all 
-                                   element delays to zero phasing them to zenith 
-                 'pointing_center' [numpy array] This will apply in the absence 
-                                   of key 'delays'. This can be specified as a 
-                                   row vector. Should have two-columns if using 
-                                   Alt-Az coordinates, or two or three columns 
-                                   if using direction cosines. There is no 
-                                   default. The coordinate system must be 
-                                   specified in 'pointing_coords' if 
+                 'gains'           [numpy array] Complex element gains. Must be
+                                   of size equal to the number of elements as
+                                   specified by the number of rows in
+                                   'element_locs'. If set to None (default), all
+                                   element gains are assumed to be unity.
+                 'delays'          [numpy array] Delays (in seconds) to be
+                                   applied to the tile elements. Size should be
+                                   equal to number of tile elements (number of
+                                   rows in antpos). Default = None will set all
+                                   element delays to zero phasing them to zenith
+                 'pointing_center' [numpy array] This will apply in the absence
+                                   of key 'delays'. This can be specified as a
+                                   row vector. Should have two-columns if using
+                                   Alt-Az coordinates, or two or three columns
+                                   if using direction cosines. There is no
+                                   default. The coordinate system must be
+                                   specified in 'pointing_coords' if
                                    'pointing_center' is to be used.
-                 'pointing_coords' [string scalar] Coordinate system in which 
-                                   the pointing_center is specified. Accepted 
-                                   values are 'altaz' or 'dircos'. Must be 
-                                   provided if 'pointing_center' is to be used. 
+                 'pointing_coords' [string scalar] Coordinate system in which
+                                   the pointing_center is specified. Accepted
+                                   values are 'altaz' or 'dircos'. Must be
+                                   provided if 'pointing_center' is to be used.
                                    No default.
-                 'delayerr'        [int, float] RMS jitter in delays used in 
-                                   the beamformer. Random jitters are drawn 
-                                   from a normal distribution with this rms. 
-                                   Must be a non-negative scalar. If not 
-                                   provided, it defaults to 0 (no jitter). 
-  
+                 'delayerr'        [int, float] RMS jitter in delays used in
+                                   the beamformer. Random jitters are drawn
+                                   from a normal distribution with this rms.
+                                   Must be a non-negative scalar. If not
+                                   provided, it defaults to 0 (no jitter).
+
     telescope   [dictionary] Contains information about the telescope parameters
                 using which the primary beams in the regions of interest are
                 determined. It specifies the type of element, element size and
                 orientation. It consists of the following keys and information:
-                'id'          [string] If set, will ignore the other keys and 
-                              use telescope details for known telescopes. 
-                              Accepted values are 'mwa', 'vla', 'gmrt', 'hera', 
-                              'paper', 'hirax', 'chime' and 'mwa_tools'. If 
-                              using 'mwa_tools', the MWA_Tools and mwapb modules 
-                              must be installed and imported.  
+                'id'          [string] If set, will ignore the other keys and
+                              use telescope details for known telescopes.
+                              Accepted values are 'mwa', 'vla', 'gmrt', 'hera',
+                              'paper', 'hirax', 'chime' and 'mwa_tools'. If
+                              using 'mwa_tools', the MWA_Tools and mwapb modules
+                              must be installed and imported.
                 'shape'       [string] Shape of antenna element. Accepted values
-                              are 'dipole', 'delta', and 'dish'. Will be ignored 
+                              are 'dipole', 'delta', and 'dish'. Will be ignored
                               if key 'id' is set. 'delta' denotes a delta
                               function for the antenna element which has an
-                              isotropic radiation pattern. 'delta' is the 
+                              isotropic radiation pattern. 'delta' is the
                               default when keys 'id' and 'shape' are not set.
-                'size'        [scalar] Diameter of the telescope dish (in 
-                              meters) if the key 'shape' is set to 'dish' or 
-                              length of the dipole if key 'shape' is set to 
-                              'dipole'. Will be ignored if key 'shape' is set to 
-                              'delta'. Will be ignored if key 'id' is set and a 
+                'size'        [scalar] Diameter of the telescope dish (in
+                              meters) if the key 'shape' is set to 'dish' or
+                              length of the dipole if key 'shape' is set to
+                              'dipole'. Will be ignored if key 'shape' is set to
+                              'delta'. Will be ignored if key 'id' is set and a
                               preset value used for the diameter or dipole.
-                'orientation' [list or numpy array] If key 'shape' is set to 
-                              dipole, it refers to the orientation of the dipole 
-                              element unit vector whose magnitude is specified 
-                              by length. If key 'shape' is set to 'dish', it 
-                              refers to the position on the sky to which the 
-                              dish is pointed. For a dipole, this unit vector 
-                              must be provided in the local ENU coordinate 
-                              system aligned with the direction cosines 
-                              coordinate system or in the Alt-Az coordinate 
-                              system. This will be used only when key 'shape' 
-                              is set to 'dipole'. This could be a 2-element 
-                              vector (transverse direction cosines) where the 
-                              third (line-of-sight) component is determined, 
-                              or a 3-element vector specifying all three 
-                              direction cosines or a two-element coordinate in 
-                              Alt-Az system. If not provided it defaults to an 
+                'orientation' [list or numpy array] If key 'shape' is set to
+                              dipole, it refers to the orientation of the dipole
+                              element unit vector whose magnitude is specified
+                              by length. If key 'shape' is set to 'dish', it
+                              refers to the position on the sky to which the
+                              dish is pointed. For a dipole, this unit vector
+                              must be provided in the local ENU coordinate
+                              system aligned with the direction cosines
+                              coordinate system or in the Alt-Az coordinate
+                              system. This will be used only when key 'shape'
+                              is set to 'dipole'. This could be a 2-element
+                              vector (transverse direction cosines) where the
+                              third (line-of-sight) component is determined,
+                              or a 3-element vector specifying all three
+                              direction cosines or a two-element coordinate in
+                              Alt-Az system. If not provided it defaults to an
                               eastward pointing dipole. If key
-                              'shape' is set to 'dish', the orientation refers 
+                              'shape' is set to 'dish', the orientation refers
                               to the pointing center of the dish on the sky. It
                               can be provided in Alt-Az system as a two-element
                               vector or in the direction cosine coordinate
                               system as a two- or three-element vector. If not
-                              set in the case of a dish element, it defaults to 
+                              set in the case of a dish element, it defaults to
                               zenith. This is not to be confused with the key
-                              'pointing_center' in dictionary 'pointing_info' 
+                              'pointing_center' in dictionary 'pointing_info'
                               which refers to the beamformed pointing center of
-                              the array. The coordinate system is specified by 
+                              the array. The coordinate system is specified by
                               the key 'ocoords'
-                'ocoords'     [scalar string] specifies the coordinate system 
+                'ocoords'     [scalar string] specifies the coordinate system
                               for key 'orientation'. Accepted values are 'altaz'
-                              and 'dircos'. 
+                              and 'dircos'.
                 'element_locs'
                               [2- or 3-column array] Element locations that
                               constitute the tile. Each row specifies
@@ -3372,41 +3372,41 @@ class ROI_parameters(object):
                               locations must be specified in local ENU
                               coordinate system. First column specifies along
                               local east, second along local north and the
-                              third along local up. If only two columns are 
-                              specified, the third column is assumed to be 
+                              third along local up. If only two columns are
+                              specified, the third column is assumed to be
                               zeros. If 'elements_locs' is not provided, it
                               assumed to be a one-element system and not a
-                              phased array as far as determination of primary 
+                              phased array as far as determination of primary
                               beam is concerned.
-                'groundplane' [scalar] height of telescope element above the 
+                'groundplane' [scalar] height of telescope element above the
                               ground plane (in meteres). Default = None will
                               denote no ground plane effects.
                 'ground_modify'
                               [dictionary] contains specifications to modify
                               the analytically computed ground plane pattern. If
                               absent, the ground plane computed will not be
-                              modified. If set, it may contain the following 
+                              modified. If set, it may contain the following
                               keys:
-                              'scale' [scalar] positive value to scale the 
-                                      modifying factor with. If not set, the 
+                              'scale' [scalar] positive value to scale the
+                                      modifying factor with. If not set, the
                                       scale factor to the modification is unity.
-                              'max'   [scalar] positive value to clip the 
-                                      modified and scaled values to. If not set, 
+                              'max'   [scalar] positive value to clip the
+                                      modified and scaled values to. If not set,
                                       there is no upper limit
                 'latitude'    [scalar] specifies latitude of the telescope site
-                              (in degrees). Default = None, otherwise should 
-                              equal the value specified during initialization 
+                              (in degrees). Default = None, otherwise should
+                              equal the value specified during initialization
                               of the instance
                 'longitude'   [scalar] specifies longitude of the telescope site
-                              (in degrees). Default = None, otherwise should 
-                              equal the value specified during initialization 
+                              (in degrees). Default = None, otherwise should
+                              equal the value specified during initialization
                               of the instance
                 'altitude'    [scalar] specifies altitude of the telescope site
-                              (in m). Default = None, otherwise should 
-                              equal the value specified during initialization 
+                              (in m). Default = None, otherwise should
+                              equal the value specified during initialization
                               of the instance
                 'pol'         [string] specifies polarization when using
-                              MWA_Tools for primary beam computation. Value of 
+                              MWA_Tools for primary beam computation. Value of
                               key 'id' in attribute dictionary telescope must be
                               set to 'mwa_tools'. 'X' or 'x' denotes
                               X-polarization. Y-polarization is specified by 'Y'
@@ -3474,10 +3474,10 @@ class ROI_parameters(object):
                 if not pbeam_input: # Will require sky positions in Alt-Az coordinates
                     if skymodel.coords == 'radec':
                         if self.telescope['latitude'] is None:
-                            raise ValueError('Latitude of the observatory must be provided.')                        
+                            raise ValueError('Latitude of the observatory must be provided.')
                         if lst is None:
                             raise ValueError('LST must be provided.')
-                        skypos_altaz = GEOM.hadec2altaz(NP.hstack((NP.asarray(lst-skymodel.location[:,0]).reshape(-1,1), skymodel.location[:,1].reshape(-1,1))), self.telescope['latitude'], units='degrees')                        
+                        skypos_altaz = GEOM.hadec2altaz(NP.hstack((NP.asarray(lst-skymodel.location[:,0]).reshape(-1,1), skymodel.location[:,1].reshape(-1,1))), self.telescope['latitude'], units='degrees')
                     elif skymodel.coords == 'hadec':
                         if self.telescope['latitude'] is None:
                             raise ValueError('Latitude of the observatory must be provided.')
@@ -3514,7 +3514,7 @@ class ROI_parameters(object):
                     if lst is None:
                         raise KeyError('LST not provided for coordinate conversion')
                     hadec = NP.asarray([lst-roi_info['center'][0,0], roi_info['center'][0,1]]).reshape(1,-1)
-                    self.info['center'] += [GEOM.hadec2altaz(hadec, self.telescope['latitude'], units='degrees')]                    
+                    self.info['center'] += [GEOM.hadec2altaz(hadec, self.telescope['latitude'], units='degrees')]
                 elif roi_info['center_coords'] == 'dircos':
                     self.info['center'] += [GEOM.dircos2altaz(roi_info['center'], units='degrees')]
                 else:
@@ -3526,7 +3526,7 @@ class ROI_parameters(object):
 
                 if lst is None:
                     raise ValueError('LST must be provided.')
-                skypos_altaz = GEOM.hadec2altaz(NP.hstack((NP.asarray(lst-skymodel.location[:,0]).reshape(-1,1), skymodel.location[:,1].reshape(-1,1))), self.telescope['latitude'], units='degrees')                
+                skypos_altaz = GEOM.hadec2altaz(NP.hstack((NP.asarray(lst-skymodel.location[:,0]).reshape(-1,1), skymodel.location[:,1].reshape(-1,1))), self.telescope['latitude'], units='degrees')
             elif skymodel.coords == 'hadec':
                 if self.telescope['latitude'] is None:
                     raise ValueError('Latitude of the observatory must be provided.')
@@ -3537,7 +3537,7 @@ class ROI_parameters(object):
                 skypos_altaz = skymodel.location
             else:
                 raise KeyError('skycoords invalid or unspecified in skymodel')
-            
+
             dtheta = GEOM.sphdist(self.info['center'][-1][0,1], self.info['center'][-1][0,0], 270.0, 90.0)
             if dtheta > 1e-2: # ROI center is not zenith
                 m1, m2, d12 = GEOM.spherematch(self.info['center'][-1][0,0], self.info['center'][-1][0,1], skypos_altaz[:,0], skypos_altaz[:,1], roi_info['radius'], maxmatches=0)
@@ -3575,7 +3575,7 @@ class ROI_parameters(object):
                 if self.telescope['id'] == 'mwa_tools':
                     if not mwa_tools_found:
                         raise ImportError('MWA_Tools could not be imported which is required for power pattern computation.')
-    
+
                     pbeam = NP.empty((ind.size, self.freq.size))
                     for i in xrange(self.freq.size):
                         pbx_MWA, pby_MWA = MWAPB.MWA_Tile_advanced(NP.radians(90.0-skypos_altaz[ind,0]).reshape(-1,1), NP.radians(skypos_altaz[ind,1]).reshape(-1,1), freq=self.freq[i], delays=self.pinfo[-1]['delays']/435e-12)
@@ -3612,14 +3612,14 @@ class ROI_parameters(object):
 
         Keyword Input(s):
 
-        tabtype      [string] indicates table type for one of the extensions in 
-                     the FITS file. Allowed values are 'BinTableHDU' and 
+        tabtype      [string] indicates table type for one of the extensions in
+                     the FITS file. Allowed values are 'BinTableHDU' and
                      'TableHDU' for binary ascii tables respectively. Default is
                      'BinTableHDU'.
-                     
-        overwrite    [boolean] True indicates overwrite even if a file already 
+
+        overwrite    [boolean] True indicates overwrite even if a file already
                      exists. Default = False (does not overwrite)
-                     
+
         verbose      [boolean] If True (default), prints diagnostic and progress
                      messages. If False, suppress printing such messages.
         ----------------------------------------------------------------------------
@@ -3630,7 +3630,7 @@ class ROI_parameters(object):
         except NameError:
             raise NameError('No filename provided. Aborting ROI_parameters.save()...')
 
-        filename = infile + '.fits' 
+        filename = infile + '.fits'
 
         if verbose:
             print '\nSaving information about regions of interest...'
@@ -3664,7 +3664,7 @@ class ROI_parameters(object):
 
         if 'element_locs' in self.telescope:
             hdulist += [fits.ImageHDU(self.telescope['element_locs'], name='Antenna element locations')]
-        
+
         hdulist += [fits.ImageHDU(self.freq, name='FREQ')]
         if verbose:
             print '\t\tCreated an extension HDU of {0:0d} frequency channels'.format(self.freq.size)
@@ -3680,14 +3680,14 @@ class ROI_parameters(object):
                             hdulist[-1].header['delayerr'] = (self.pinfo[i]['delayerr'], 'Jitter in delays [s]')
                         else:
                             hdulist[-1].header['delayerr'] = (0.0, 'Jitter in delays [s]')
-    
+
                 if 'pointing_center' in self.pinfo[i]:
                     hdulist += [fits.ImageHDU(self.pinfo[i]['pointing_center'], name='POINTING_CENTER_{0:0d}'.format(i))]
                     if 'pointing_coords' in self.pinfo[i]:
                         hdulist[-1].header['pointing_coords'] = (self.pinfo[i]['pointing_coords'], 'Pointing coordinate system')
                     else:
                         raise KeyError('Key "pointing_coords" not found in attribute pinfo.')
-                
+
         if verbose:
             print '\t\tCreated HDU extensions for {0:0d} observations containing ROI indices and primary beams'.format(len(self.info['ind']))
 
@@ -3706,7 +3706,7 @@ class InterferometerArray(object):
 
     """
     ----------------------------------------------------------------------------
-    Class to manage information on a multi-element interferometer array. 
+    Class to manage information on a multi-element interferometer array.
 
     Attributes:
 
@@ -3718,20 +3718,20 @@ class InterferometerArray(object):
 
     baselines:  [M x 3 Numpy array] The baseline vectors associated with the
                 M interferometers in SI units. The coordinate system of these
-                vectors is specified by another attribute baseline_coords. 
+                vectors is specified by another attribute baseline_coords.
 
     baseline_coords
-                [string] Coordinate system for the baseline vectors. Default is 
-                'localenu'. Other accepted values are 'equatorial' 
+                [string] Coordinate system for the baseline vectors. Default is
+                'localenu'. Other accepted values are 'equatorial'
 
     baseline_lengths
                 [M-element numpy array] Lengths of the baseline in SI units
 
     projected_baselines
-                [M x 3 x n_snaps Numpy array] The projected baseline vectors 
-                associated with the M interferometers and number of snapshots in 
-                SI units. The coordinate system of these vectors is specified by 
-                either pointing_center, phase_center or as specified in input to 
+                [M x 3 x n_snaps Numpy array] The projected baseline vectors
+                associated with the M interferometers and number of snapshots in
+                SI units. The coordinate system of these vectors is specified by
+                either pointing_center, phase_center or as specified in input to
                 member function project_baselines().
 
     bp          [numpy array] Bandpass weights of size n_baselines x nchan x
@@ -3740,30 +3740,30 @@ class InterferometerArray(object):
                 n_baselines is the number of baselines
 
     bp_wts      [numpy array] Additional weighting to be applied to the bandpass
-                shapes during the application of the member function 
-                delay_transform(). Same size as attribute bp. 
+                shapes during the application of the member function
+                delay_transform(). Same size as attribute bp.
 
     channels    [list or numpy vector] frequency channels in Hz
 
     eff_Q       [scalar, list or numpy vector] Efficiency of the interferometers,
-                one value for each interferometer. Default = 0.89, appropriate 
+                one value for each interferometer. Default = 0.89, appropriate
                 for the VLA. Has to be between 0 and 1. If only a scalar value
-                provided, it will be assumed to be identical for all the 
+                provided, it will be assumed to be identical for all the
                 interferometers. Otherwise, one value must be provided for each
                 of the interferometers.
 
     freq_resolution
                 [scalar] Frequency resolution (in Hz)
 
-    labels:     [list of 2-element tuples] A unique identifier (tuple of 
-                strings) for each of the interferometers. 
+    labels:     [list of 2-element tuples] A unique identifier (tuple of
+                strings) for each of the interferometers.
 
     lags        [numpy vector] Time axis obtained when the frequency axis is
-                inverted using a FFT. Same size as channels. This is 
+                inverted using a FFT. Same size as channels. This is
                 computed in member function delay_transform().
 
-    lag_kernel  [numpy array] Inverse Fourier Transform of the frequency 
-                bandpass shape. In other words, it is the impulse response 
+    lag_kernel  [numpy array] Inverse Fourier Transform of the frequency
+                bandpass shape. In other words, it is the impulse response
                 corresponding to frequency bandpass. Same size as attributes
                 bp and bp_wts. It is initialized in __init__() member function
                 but effectively computed in member function delay_transform()
@@ -3778,21 +3778,21 @@ class InterferometerArray(object):
 
     n_acc       [scalar] Number of accumulations
 
-    gaininfo    [None or instance of class GainInfo] Instance of class 
+    gaininfo    [None or instance of class GainInfo] Instance of class
                 Gaininfo. If set to None, default gains assumed to be unity.
 
     gradient_mode
-                [string] If set to None, visibilities will be simulated as 
-                usual. If set to string, both visibilities and visibility 
-                gradients with respect to the quantity specified in the 
-                string will be simulated. Currently accepted value is 
-                'baseline'. Plan to incorporate gradients with respect to 
+                [string] If set to None, visibilities will be simulated as
+                usual. If set to string, both visibilities and visibility
+                gradients with respect to the quantity specified in the
+                string will be simulated. Currently accepted value is
+                'baseline'. Plan to incorporate gradients with respect to
                 'skypos' and 'frequency' as well in the future.
 
-    gradient    [dictionary] If gradient_mode is set to None, it is an empty 
+    gradient    [dictionary] If gradient_mode is set to None, it is an empty
                 dictionary. If gradient_mode is not None, this quantity holds
-                the gradient under the key specified by gradient_mode. 
-                Currently, supports 'baseline' key. Other gradients will be 
+                the gradient under the key specified by gradient_mode.
+                Currently, supports 'baseline' key. Other gradients will be
                 supported in future. It contains the following keys and values.
                 If gradient_mode == 'baseline':
                 'baseline'  [numpy array] Visibility gradients with respect to
@@ -3802,41 +3802,41 @@ class InterferometerArray(object):
     obs_catalog_indices
                 [list of lists] Each element in the top list corresponds to a
                 timestamp. Inside each top list is a list of indices of sources
-                from the catalog which are observed inside the region of 
-                interest. This is computed inside member function observe(). 
+                from the catalog which are observed inside the region of
+                interest. This is computed inside member function observe().
 
     pointing_center
-                [2-column numpy array] Pointing center (latitude and 
-                longitude) of the observation at a given timestamp. This is 
-                where the telescopes will be phased up to as reference. 
-                Coordinate system for the pointing_center is specified by another 
+                [2-column numpy array] Pointing center (latitude and
+                longitude) of the observation at a given timestamp. This is
+                where the telescopes will be phased up to as reference.
+                Coordinate system for the pointing_center is specified by another
                 attribute pointing_coords.
 
     phase_center
-                [2-column numpy array] Phase center (latitude and 
-                longitude) of the observation at a given timestamp. This is 
-                where the telescopes will be phased up to as reference. 
-                Coordinate system for the phase_center is specified by another 
+                [2-column numpy array] Phase center (latitude and
+                longitude) of the observation at a given timestamp. This is
+                where the telescopes will be phased up to as reference.
+                Coordinate system for the phase_center is specified by another
                 attribute phase_center_coords.
 
     pointing_coords
-                [string] Coordinate system for telescope pointing. Accepted 
-                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz' 
+                [string] Coordinate system for telescope pointing. Accepted
+                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz'
                 (Altitude-Azimuth). Default = 'hadec'.
 
     phase_center_coords
-                [string] Coordinate system for array phase center. Accepted 
-                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz' 
+                [string] Coordinate system for array phase center. Accepted
+                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz'
                 (Altitude-Azimuth). Default = 'hadec'.
 
     skycoords   [string] Coordinate system for the sky positions of sources.
-                Accepted values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 
+                Accepted values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or
                 'altaz' (Altitude-Azimuth). Default = 'radec'.
-    
-    skyvis_freq [numpy array] Complex visibility due to sky emission (in Jy or K) 
+
+    skyvis_freq [numpy array] Complex visibility due to sky emission (in Jy or K)
                 along frequency axis for each interferometer estimated from the
                 specified external catalog. Same size as vis_freq. Used in the
-                member function observe(). Read its docstring for more details. 
+                member function observe(). Read its docstring for more details.
                 Has dimensions n_baselines x nchan x n_snaps.
 
     skyvis_lag  [numpy array] Complex visibility due to sky emission (in Jy Hz or
@@ -3849,78 +3849,78 @@ class InterferometerArray(object):
                 element size and orientation. It consists of the following keys
                 and values:
                 'id'          [string] If set, will ignore the other keys and use
-                              telescope details for known telescopes. Accepted 
-                              values are 'mwa', 'vla', 'gmrt', 'hera', 'paper', 
-                              'hirax', 'chime'and other custom values. 
+                              telescope details for known telescopes. Accepted
+                              values are 'mwa', 'vla', 'gmrt', 'hera', 'paper',
+                              'hirax', 'chime'and other custom values.
                               Default = 'mwa'
                 'shape'       [string] Shape of antenna element. Accepted values
-                              are 'dipole', 'delta', and 'dish'. Will be ignored 
+                              are 'dipole', 'delta', and 'dish'. Will be ignored
                               if key 'id' is set. 'delta' denotes a delta
                               function for the antenna element which has an
                               isotropic radiation pattern. 'dish' is the default
                               when keys 'id' and 'shape' are not set.
-                'size'        [scalar] Diameter of the telescope dish (in meters) 
-                              if the key 'shape' is set to 'dish' or length of 
-                              the dipole if key 'shape' is set to 'dipole'. Will 
-                              be ignored if key 'shape' is set to 'delta'. Will 
-                              be ignored if key 'id' is set and a preset value 
+                'size'        [scalar] Diameter of the telescope dish (in meters)
+                              if the key 'shape' is set to 'dish' or length of
+                              the dipole if key 'shape' is set to 'dipole'. Will
+                              be ignored if key 'shape' is set to 'delta'. Will
+                              be ignored if key 'id' is set and a preset value
                               used for the diameter or dipole. Default = 25.0.
-                'orientation' [list or numpy array] If key 'shape' is set to 
-                              dipole, it refers to the orientation of the dipole 
-                              element unit vector whose magnitude is specified by 
-                              length. If key 'shape' is set to 'dish', it refers 
+                'orientation' [list or numpy array] If key 'shape' is set to
+                              dipole, it refers to the orientation of the dipole
+                              element unit vector whose magnitude is specified by
+                              length. If key 'shape' is set to 'dish', it refers
                               to the position on the sky to which the dish is
                               pointed. For a dipole, this unit vector must be
-                              provided in the local ENU coordinate system aligned 
+                              provided in the local ENU coordinate system aligned
                               with the direction cosines coordinate system or in
-                              the Alt-Az coordinate system. 
-                              This could be a 2-element vector (transverse 
-                              direction cosines) where the third (line-of-sight) 
+                              the Alt-Az coordinate system.
+                              This could be a 2-element vector (transverse
+                              direction cosines) where the third (line-of-sight)
                               component is determined, or a 3-element vector
                               specifying all three direction cosines or a two-
-                              element coordinate in Alt-Az system. If not provided 
+                              element coordinate in Alt-Az system. If not provided
                               it defaults to an eastward pointing dipole. If key
-                              'shape' is set to 'dish', the orientation refers 
+                              'shape' is set to 'dish', the orientation refers
                               to the pointing center of the dish on the sky. It
                               can be provided in Alt-Az system as a two-element
                               vector or in the direction cosine coordinate
                               system as a two- or three-element vector. If not
-                              set in the case of a dish element, it defaults to 
-                              zenith. The coordinate system is specified by 
+                              set in the case of a dish element, it defaults to
+                              zenith. The coordinate system is specified by
                               the key 'ocoords'
-                'ocoords'     [scalar string] specifies the coordinate system 
+                'ocoords'     [scalar string] specifies the coordinate system
                               for key 'orientation'. Accepted values are 'altaz'
-                              and 'dircos'. 
-                'groundplane' [scalar] height of telescope element above the 
+                              and 'dircos'.
+                'groundplane' [scalar] height of telescope element above the
                               ground plane (in meteres). Default = None will
                               denote no ground plane effects.
                 'ground_modify'
                               [dictionary] contains specifications to modify
                               the analytically computed ground plane pattern. If
                               absent, the ground plane computed will not be
-                              modified. If set, it may contain the following 
+                              modified. If set, it may contain the following
                               keys:
-                              'scale' [scalar] positive value to scale the 
-                                      modifying factor with. If not set, the 
+                              'scale' [scalar] positive value to scale the
+                                      modifying factor with. If not set, the
                                       scale factor to the modification is unity.
-                              'max'   [scalar] positive value to clip the 
-                                      modified and scaled values to. If not set, 
+                              'max'   [scalar] positive value to clip the
+                                      modified and scaled values to. If not set,
                                       there is no upper limit
 
     layout      [dictionary] contains array layout information (on the full
                 array even if only a subset of antennas or baselines are used
-                in the simulation). It contains the following keys and 
+                in the simulation). It contains the following keys and
                 information:
-                'positions' [numpy array] Antenna positions (in m) as a 
+                'positions' [numpy array] Antenna positions (in m) as a
                             nant x 3 array in coordinates specified by key
                             'coords'
-                'coords'    [string] Coordinate system in which antenna 
+                'coords'    [string] Coordinate system in which antenna
                             positions are specified. Currently accepts 'ENU'
                             for local ENU system
                 'labels'    [list or numpy array of strings] Unique string
                             identifiers for antennas. Must be of same length
                             as nant.
-                'ids'       [list or numpy array of integers] Unique integer 
+                'ids'       [list or numpy array of integers] Unique integer
                             identifiers for antennas. Must be of same length
                             as nant.
 
@@ -3930,77 +3930,77 @@ class InterferometerArray(object):
 
     t_obs       [scalar] Total observing duration (sec)
 
-    Tsys        [scalar, list or numpy vector] System temperature in Kelvin. At 
-                end of the simulation, it will be a numpy array of size 
+    Tsys        [scalar, list or numpy vector] System temperature in Kelvin. At
+                end of the simulation, it will be a numpy array of size
                 n_baselines x nchan x n_snaps.
 
-    Tsysinfo    [list of dictionaries] Contains a list of system temperature 
-                information for each timestamp of observation. Each dictionary 
+    Tsysinfo    [list of dictionaries] Contains a list of system temperature
+                information for each timestamp of observation. Each dictionary
                 element in the list following keys and values:
-                'Trx'      [scalar] Recevier temperature (in K) that is 
+                'Trx'      [scalar] Recevier temperature (in K) that is
                            applicable to all frequencies and baselines
                 'Tant'     [dictionary] contains antenna temperature info
-                           from which the antenna temperature is estimated. 
-                           Used only if the key 'Tnet' is absent or set to 
+                           from which the antenna temperature is estimated.
+                           Used only if the key 'Tnet' is absent or set to
                            None. It has the following keys and values:
-                           'f0'      [scalar] Reference frequency (in Hz) 
-                                     from which antenna temperature will 
+                           'f0'      [scalar] Reference frequency (in Hz)
+                                     from which antenna temperature will
                                      be estimated (see formula below)
                            'T0'      [scalar] Antenna temperature (in K) at
-                                     the reference frequency specified in 
+                                     the reference frequency specified in
                                      key 'f0'. See formula below.
                            'spindex' [scalar] Antenna temperature spectral
                                      index. See formula below.
 
                            Tsys = Trx + Tant['T0'] * (f/Tant['f0'])**spindex
 
-                'Tnet'     [numpy array] Pre-computed Tsys (in K) 
+                'Tnet'     [numpy array] Pre-computed Tsys (in K)
                            information that will be used directly to set the
-                           Tsys. If specified, the information under keys 
-                           'Trx' and 'Tant' will be ignored. If a scalar 
-                           value is provided, it will be assumed to be 
-                           identical for all interferometers and all 
-                           frequencies. If a vector is provided whose length 
-                           is equal to the number of interferoemters, it 
-                           will be assumed identical for all frequencies. If 
-                           a vector is provided whose length is equal to the 
-                           number of frequency channels, it will be assumed 
-                           identical for all interferometers. If a 2D array 
-                           is provided, it should be of size 
+                           Tsys. If specified, the information under keys
+                           'Trx' and 'Tant' will be ignored. If a scalar
+                           value is provided, it will be assumed to be
+                           identical for all interferometers and all
+                           frequencies. If a vector is provided whose length
+                           is equal to the number of interferoemters, it
+                           will be assumed identical for all frequencies. If
+                           a vector is provided whose length is equal to the
+                           number of frequency channels, it will be assumed
+                           identical for all interferometers. If a 2D array
+                           is provided, it should be of size
                            n_baselines x nchan. Tsys = Tnet
 
-    vis_freq    [numpy array] The simulated complex visibility (in Jy or K) 
-                observed by each of the interferometers along frequency axis for 
+    vis_freq    [numpy array] The simulated complex visibility (in Jy or K)
+                observed by each of the interferometers along frequency axis for
                 each timestamp of observation per frequency channel. It is the
                 sum of skyvis_freq and vis_noise_freq. It can be either directly
                 initialized or simulated in observe(). Same dimensions as
                 skyvis_freq.
 
-    vis_lag     [numpy array] The simulated complex visibility (in Jy Hz or K Hz) 
+    vis_lag     [numpy array] The simulated complex visibility (in Jy Hz or K Hz)
                 along delay axis for each interferometer obtained by FFT of
                 vis_freq along frequency axis. Same size as vis_noise_lag and
-                skyis_lag. It is evaluated in member function delay_transform(). 
+                skyis_lag. It is evaluated in member function delay_transform().
 
     vis_noise_freq
-                [numpy array] Complex visibility noise (in Jy or K) generated 
-                using an rms of vis_rms_freq along frequency axis for each 
+                [numpy array] Complex visibility noise (in Jy or K) generated
+                using an rms of vis_rms_freq along frequency axis for each
                 interferometer which is then added to the generated sky
-                visibility. Same dimensions as skyvis_freq. Used in the member 
-                function observe(). Read its docstring for more details. 
+                visibility. Same dimensions as skyvis_freq. Used in the member
+                function observe(). Read its docstring for more details.
 
     vis_noise_lag
-                [numpy array] Complex visibility noise (in Jy Hz or K Hz) along 
+                [numpy array] Complex visibility noise (in Jy Hz or K Hz) along
                 delay axis for each interferometer generated using an FFT of
                 vis_noise_freq along frequency axis. Same size as vis_noise_freq.
                 Created in the member function delay_transform(). Read its
-                docstring for more details. 
+                docstring for more details.
 
     vis_rms_freq
                 [list of float] Theoretically estimated thermal noise rms (in Jy
-                or K) in visibility measurements. Same size as vis_freq. This 
-                will be estimated and used to inject simulated noise when a call 
-                to member function observe() is made. Read the  docstring of 
-                observe() for more details. The noise rms is estimated from the 
+                or K) in visibility measurements. Same size as vis_freq. This
+                will be estimated and used to inject simulated noise when a call
+                to member function observe() is made. Read the  docstring of
+                observe() for more details. The noise rms is estimated from the
                 instrument parameters as:
                 (2 k T_sys / (A_eff x sqrt(2 x channel_width x t_acc))) / Jy, or
                 T_sys / sqrt(2 x channel_width x t_acc)
@@ -4008,17 +4008,17 @@ class InterferometerArray(object):
     simparms_file
                 [string] Full path to filename containing simulation parameters
                 in YAML format
- 
+
     Member functions:
 
     __init__()          Initializes an instance of class InterferometerArray
-                        
+
     observe()           Simulates an observing run with the interferometer
                         specifications and an external sky catalog thus producing
                         visibilities. The simulation generates visibilities
                         observed by the interferometer for the specified
                         parameters.
-                        
+
     observing_run()     Simulate an extended observing run in 'track' or 'drift'
                         mode, by an instance of the InterferometerArray class, of
                         the sky when a sky catalog is provided. The simulation
@@ -4027,69 +4027,69 @@ class InterferometerArray(object):
                         observe() and builds the observation from snapshots. The
                         timestamp for each snapshot is the current time at which
                         the snapshot is generated.
-                        
-    generate_noise()    Generates thermal noise from attributes that describe 
+
+    generate_noise()    Generates thermal noise from attributes that describe
                         system parameters which can be added to sky visibilities
-                        
-    add_noise()         Adds the thermal noise generated in member function 
-                        generate_noise() to the sky visibilities after 
+
+    add_noise()         Adds the thermal noise generated in member function
+                        generate_noise() to the sky visibilities after
                         extracting and applying complex instrument gains
-                        
+
     rotate_visibilities()
-                        Centers the phase of visibilities around any given phase 
-                        center. Project baseline vectors with respect to a 
+                        Centers the phase of visibilities around any given phase
+                        center. Project baseline vectors with respect to a
                         reference point on the sky. Essentially a wrapper to
-                        member functions phase_centering() and 
+                        member functions phase_centering() and
                         project_baselines()
 
-    phase_centering()   Centers the phase of visibilities around any given phase 
+    phase_centering()   Centers the phase of visibilities around any given phase
                         center.
-                        
-    project_baselines() Project baseline vectors with respect to a reference 
-                        point on the sky. Assigns the projected baselines to the 
+
+    project_baselines() Project baseline vectors with respect to a reference
+                        point on the sky. Assigns the projected baselines to the
                         attribute projected_baselines
 
-    conjugate()         Flips the baseline vectors and conjugates the visibilies 
+    conjugate()         Flips the baseline vectors and conjugates the visibilies
                         for a specified subset of baselines.
 
-    delay_transform()  Transforms the visibilities from frequency axis onto 
-                       delay (time) axis using an IFFT. This is performed for 
-                       noiseless sky visibilities, thermal noise in visibilities, 
-                       and observed visibilities. 
+    delay_transform()  Transforms the visibilities from frequency axis onto
+                       delay (time) axis using an IFFT. This is performed for
+                       noiseless sky visibilities, thermal noise in visibilities,
+                       and observed visibilities.
 
-    concatenate()      Concatenates different visibility data sets from instances 
+    concatenate()      Concatenates different visibility data sets from instances
                        of class InterferometerArray along baseline, frequency or
                        time axis.
 
     save()             Saves the interferometer array information to disk in
                        HDF5, FITS, NPZ and UVFITS formats
 
-    write_uvfits()     Saves the interferometer array information to disk in 
-                       UVFITS format 
+    write_uvfits()     Saves the interferometer array information to disk in
+                       UVFITS format
 
     ----------------------------------------------------------------------------
     """
 
     def __init__(self, labels, baselines, channels, telescope=None, eff_Q=0.89,
-                 latitude=34.0790, longitude=0.0, altitude=0.0, 
-                 skycoords='radec', A_eff=NP.pi*(25.0/2)**2, 
-                 pointing_coords='hadec', layout=None, 
+                 latitude=34.0790, longitude=0.0, altitude=0.0,
+                 skycoords='radec', A_eff=NP.pi*(25.0/2)**2,
+                 pointing_coords='hadec', layout=None,
                  baseline_coords='localenu', freq_scale=None, gaininfo=None,
                  init_file=None, simparms_file=None):
-        
+
         """
         ------------------------------------------------------------------------
-        Intialize the InterferometerArray class which manages information on a 
+        Intialize the InterferometerArray class which manages information on a
         multi-element interferometer.
 
         Class attributes initialized are:
-        labels, baselines, channels, telescope, latitude, longitude, altitude, 
-        skycoords, eff_Q, A_eff, pointing_coords, baseline_coords, 
-        baseline_lengths, channels, bp, bp_wts, freq_resolution, lags, lst, 
-        obs_catalog_indices, pointing_center, skyvis_freq, skyvis_lag, 
-        timestamp, t_acc, Tsys, Tsysinfo, vis_freq, vis_lag, t_obs, n_acc, 
-        vis_noise_freq, vis_noise_lag, vis_rms_freq, geometric_delays, 
-        projected_baselines, simparms_file, layout, gradient, gradient_mode, 
+        labels, baselines, channels, telescope, latitude, longitude, altitude,
+        skycoords, eff_Q, A_eff, pointing_coords, baseline_coords,
+        baseline_lengths, channels, bp, bp_wts, freq_resolution, lags, lst,
+        obs_catalog_indices, pointing_center, skyvis_freq, skyvis_lag,
+        timestamp, t_acc, Tsys, Tsysinfo, vis_freq, vis_lag, t_obs, n_acc,
+        vis_noise_freq, vis_noise_lag, vis_rms_freq, geometric_delays,
+        projected_baselines, simparms_file, layout, gradient, gradient_mode,
         gaininfo
 
         Read docstring of class InterferometerArray for details on these
@@ -4098,12 +4098,12 @@ class InterferometerArray(object):
         Keyword input(s):
 
         init_file    [string] Location of the initialization file from which an
-                     instance of class InterferometerArray will be created. 
-                     File format must be compatible with the one saved to disk 
+                     instance of class InterferometerArray will be created.
+                     File format must be compatible with the one saved to disk
                      by member function save().
 
         simparms_file
-                     [string] Location of the simulation parameters in YAML 
+                     [string] Location of the simulation parameters in YAML
                      format that went into making the simulated data product
 
         Other input parameters have their usual meanings. Read the docstring of
@@ -4186,7 +4186,7 @@ class InterferometerArray(object):
                                 raise KeyError('Key "orientation" not found in init_file')
                             if 'groundplane' in grp:
                                 self.telescope['groundplane'] = grp['groundplane'].value
-                                
+
                         if key == 'simparms':
                             if 'simfile' in grp:
                                 self.simparms_file = grp['simfile'].value
@@ -4246,7 +4246,7 @@ class InterferometerArray(object):
                                 self.eff_Q = grp['efficiency'].value
                             else:
                                 raise KeyError('Key "effeciency" not found in init_file')
-                            
+
                         if key == 'array':
                             if 'labels' in grp:
                                 self.labels = grp['labels'].value
@@ -4311,16 +4311,16 @@ class InterferometerArray(object):
                 except IOError:
                     argument_init = True
                     print '\tinit_file provided but could not open the initialization file. Attempting to initialize with input parameters...'
-    
+
                 extnames = [hdulist[i].header['EXTNAME'] for i in xrange(1,len(hdulist))]
-    
+
                 self.simparms_file = None
                 if 'simparms' in hdulist[0].header:
                     if isinstance(hdulist[0].header['simparms'], str):
                         self.simparms_file = hdulist[0].header['simparms']
                     else:
                         warnings.warn('\tInvalid specification found in header for simulation parameters file. Proceeding with None as default.')
-    
+
                 try:
                     self.gradient_mode = hdulist[0].header['gradient_mode']
                 except KeyError:
@@ -4332,19 +4332,19 @@ class InterferometerArray(object):
                 except KeyError:
                     hdulist.close()
                     raise KeyError('Keyword "freq_resolution" not found in header.')
-    
+
                 try:
                     self.latitude = hdulist[0].header['latitude']
                 except KeyError:
                     print '\tKeyword "latitude" not found in header. Assuming 34.0790 degrees for attribute latitude.'
                     self.latitude = 34.0790
-    
+
                 try:
                     self.longitude = hdulist[0].header['longitude']
                 except KeyError:
                     print '\tKeyword "longitude" not found in header. Assuming 0.0 degrees for attribute longitude.'
                     self.longitude = 0.0
-                    
+
                 try:
                     self.altitude = hdulist[0].header['altitude']
                 except KeyError:
@@ -4353,94 +4353,94 @@ class InterferometerArray(object):
                 self.telescope = {}
                 if 'telescope' in hdulist[0].header:
                     self.telescope['id'] = hdulist[0].header['telescope']
-    
+
                 try:
                     self.telescope['shape'] = hdulist[0].header['element_shape']
                 except KeyError:
                     print '\tKeyword "element_shape" not found in header. Assuming "delta" for attribute antenna element shape.'
                     self.telescope['shape'] = 'delta'
-    
+
                 try:
                     self.telescope['size'] = hdulist[0].header['element_size']
                 except KeyError:
                     print '\tKeyword "element_size" not found in header. Assuming 25.0m for attribute antenna element size.'
                     self.telescope['size'] = 1.0
-    
+
                 try:
                     self.telescope['ocoords'] = hdulist[0].header['element_ocoords']
                 except KeyError:
                     raise KeyError('\tKeyword "element_ocoords" not found in header. No defaults.')
-    
+
                 try:
                     self.telescope['groundplane'] = hdulist[0].header['groundplane']
                 except KeyError:
                     self.telescope['groundplane'] = None
-    
+
                 if 'ANTENNA ELEMENT ORIENTATION' not in extnames:
                     raise KeyError('No extension found containing information on element orientation.')
                 else:
                     self.telescope['orientation'] = hdulist['ANTENNA ELEMENT ORIENTATION'].data.reshape(1,-1)
-    
+
                 try:
                     self.baseline_coords = hdulist[0].header['baseline_coords']
                 except KeyError:
                     print '\tKeyword "baseline_coords" not found in header. Assuming "localenu" for attribute baseline_coords.'
                     self.baseline_coords = 'localenu'
-    
+
                 try:
                     self.pointing_coords = hdulist[0].header['pointing_coords']
                 except KeyError:
                     print '\tKeyword "pointing_coords" not found in header. Assuming "hadec" for attribute pointing_coords.'
                     self.pointing_coords = 'hadec'
-    
+
                 try:
                     self.phase_center_coords = hdulist[0].header['phase_center_coords']
                 except KeyError:
                     print '\tKeyword "phase_center_coords" not found in header. Assuming "hadec" for attribute phase_center_coords.'
                     self.phase_center_coords = 'hadec'
-    
+
                 try:
                     self.skycoords = hdulist[0].header['skycoords']
                 except KeyError:
                     print '\tKeyword "skycoords" not found in header. Assuming "radec" for attribute skycoords.'
                     self.skycoords = 'radec'
-    
+
                 try:
                     self.flux_unit = hdulist[0].header['flux_unit']
                 except KeyError:
                     print '\tKeyword "flux_unit" not found in header. Assuming "jy" for attribute flux_unit.'
                     self.flux_unit = 'JY'
-    
+
                 if 'POINTING AND PHASE CENTER INFO' not in extnames:
                     raise KeyError('No extension table found containing pointing information.')
                 else:
                     self.lst = hdulist['POINTING AND PHASE CENTER INFO'].data['LST'].tolist()
                     self.pointing_center = NP.hstack((hdulist['POINTING AND PHASE CENTER INFO'].data['pointing_longitude'].reshape(-1,1), hdulist['POINTING AND PHASE CENTER INFO'].data['pointing_latitude'].reshape(-1,1)))
                     self.phase_center = NP.hstack((hdulist['POINTING AND PHASE CENTER INFO'].data['phase_center_longitude'].reshape(-1,1), hdulist['POINTING AND PHASE CENTER INFO'].data['phase_center_latitude'].reshape(-1,1)))
-    
+
                 if 'TIMESTAMPS' in extnames:
                     self.timestamp = hdulist['TIMESTAMPS'].data['timestamps'].tolist()
                 else:
                     raise KeyError('Extension named "TIMESTAMPS" not found in init_file.')
-    
+
                 self.Tsysinfo = []
                 if 'TSYSINFO' in extnames:
                     self.Tsysinfo = [{'Trx': elem['Trx'], 'Tant': {'T0': elem['Tant0'], 'f0': elem['f0'], 'spindex': elem['spindex']}, 'Tnet': None} for elem in hdulist['TSYSINFO'].data]
-    
+
                 if 'TSYS' in extnames:
                     self.Tsys = hdulist['Tsys'].data
                 else:
                     raise KeyError('Extension named "Tsys" not found in init_file.')
-    
+
                 if 'BASELINES' in extnames:
                     self.baselines = hdulist['BASELINES'].data.reshape(-1,3)
                     self.baseline_lengths = NP.sqrt(NP.sum(self.baselines**2, axis=1))
                 else:
                     raise KeyError('Extension named "BASELINES" not found in init_file.')
-    
+
                 if 'PROJ_BASELINES' in extnames:
                     self.projected_baselines = hdulist['PROJ_BASELINES'].data
-    
+
                 if 'LABELS' in extnames:
                     # self.labels = hdulist['LABELS'].data.tolist()
                     a1 = hdulist['LABELS'].data['A1']
@@ -4448,7 +4448,7 @@ class InterferometerArray(object):
                     self.labels = zip(a2,a1)
                 else:
                     self.labels = ['B{0:0d}'.format(i+1) for i in range(self.baseline_lengths.size)]
-    
+
                 self.layout = {}
                 if 'LAYOUT' in extnames:
                     for key in ['positions', 'ids', 'labels']:
@@ -4459,12 +4459,12 @@ class InterferometerArray(object):
                     self.A_eff = hdulist['EFFECTIVE AREA'].data
                 else:
                     raise KeyError('Extension named "EFFECTIVE AREA" not found in init_file.')
-    
+
                 if 'INTERFEROMETER EFFICIENCY' in extnames:
                     self.eff_Q = hdulist['INTERFEROMETER EFFICIENCY'].data
                 else:
                     raise KeyError('Extension named "INTERFEROMETER EFFICIENCY" not found in init_file.')
-    
+
                 if 'SPECTRAL INFO' not in extnames:
                     raise KeyError('No extension table found containing spectral information.')
                 else:
@@ -4473,29 +4473,29 @@ class InterferometerArray(object):
                         self.lags = hdulist['SPECTRAL INFO'].data['lag']
                     except KeyError:
                         self.lags = None
-    
+
                 if 'BANDPASS' in extnames:
                     self.bp = hdulist['BANDPASS'].data
                 else:
                     raise KeyError('Extension named "BANDPASS" not found in init_file.')
-    
+
                 if 'BANDPASS_WEIGHTS' in extnames:
                     self.bp_wts = hdulist['BANDPASS_WEIGHTS'].data
                 else:
                     self.bp_wts = NP.ones_like(self.bp)
-    
+
                 if 'T_ACC' in extnames:
                     self.t_acc = hdulist['t_acc'].data.tolist()
                     self.n_acc = len(self.t_acc)
                     self.t_obs = sum(self.t_acc)
                 else:
                     raise KeyError('Extension named "T_ACC" not found in init_file.')
-                
+
                 if 'FREQ_CHANNEL_NOISE_RMS_VISIBILITY' in extnames:
                     self.vis_rms_freq = hdulist['freq_channel_noise_rms_visibility'].data
                 else:
                     self.vis_rms_freq = None
-    
+
                 if 'REAL_FREQ_OBS_VISIBILITY' in extnames:
                     self.vis_freq = hdulist['real_freq_obs_visibility'].data
                     if 'IMAG_FREQ_OBS_VISIBILITY' in extnames:
@@ -4503,7 +4503,7 @@ class InterferometerArray(object):
                         self.vis_freq += 1j * hdulist['imag_freq_obs_visibility'].data
                 else:
                     self.vis_freq = None
-    
+
                 if 'REAL_FREQ_SKY_VISIBILITY' in extnames:
                     self.skyvis_freq = hdulist['real_freq_sky_visibility'].data
                     if 'IMAG_FREQ_SKY_VISIBILITY' in extnames:
@@ -4511,7 +4511,7 @@ class InterferometerArray(object):
                         self.skyvis_freq += 1j * hdulist['imag_freq_sky_visibility'].data
                 else:
                     raise KeyError('Extension named "REAL_FREQ_SKY_VISIBILITY" not found in init_file.')
-    
+
                 if 'REAL_FREQ_NOISE_VISIBILITY' in extnames:
                     self.vis_noise_freq = hdulist['real_freq_noise_visibility'].data
                     if 'IMAG_FREQ_NOISE_VISIBILITY' in extnames:
@@ -4519,7 +4519,7 @@ class InterferometerArray(object):
                         self.vis_noise_freq += 1j * hdulist['imag_freq_noise_visibility'].data
                 else:
                     self.vis_noise_freq = None
-    
+
                 if self.gradient_mode is not None:
                     self.gradient = {}
                     if 'real_freq_sky_visibility_gradient_wrt_{0}'.format(self.gradient_mode) in extnames:
@@ -4543,7 +4543,7 @@ class InterferometerArray(object):
                         self.vis_lag += 1j * hdulist['imag_lag_visibility'].data
                 else:
                     self.vis_lag = None
-    
+
                 if 'REAL_LAG_SKY_VISIBILITY' in extnames:
                     self.skyvis_lag = hdulist['real_lag_sky_visibility'].data
                     if 'IMAG_LAG_SKY_VISIBILITY' in extnames:
@@ -4551,7 +4551,7 @@ class InterferometerArray(object):
                         self.skyvis_lag += 1j * hdulist['imag_lag_sky_visibility'].data
                 else:
                     self.skyvis_lag = None
-    
+
                 if 'REAL_LAG_NOISE_VISIBILITY' in extnames:
                     self.vis_noise_lag = hdulist['real_lag_noise_visibility'].data
                     if 'IMAG_LAG_NOISE_VISIBILITY' in extnames:
@@ -4559,13 +4559,13 @@ class InterferometerArray(object):
                         self.vis_noise_lag += 1j * hdulist['imag_lag_noise_visibility'].data
                 else:
                     self.vis_noise_lag = None
-    
+
                 hdulist.close()
             init_file_success = True
             return
         else:
             argument_init = True
-            
+
         if (not argument_init) and (not init_file_success):
             raise ValueError('Initialization failed with the use of init_file.')
 
@@ -4770,73 +4770,73 @@ class InterferometerArray(object):
 
         """
         -------------------------------------------------------------------------
-        Simulate a snapshot observation, by an instance of the 
-        InterferometerArray class, of the sky when a sky catalog is provided. The 
-        simulation generates visibilities observed by the interferometers for the 
-        specified parameters. See member function observing_run() for simulating 
+        Simulate a snapshot observation, by an instance of the
+        InterferometerArray class, of the sky when a sky catalog is provided. The
+        simulation generates visibilities observed by the interferometers for the
+        specified parameters. See member function observing_run() for simulating
         an extended observing run in 'track' or 'drift' mode.
 
         Inputs:
-        
+
         timestamp    [scalar] Timestamp associated with each integration in the
                      observation
 
-        Tsysinfo     [dictionary] Contains system temperature information for 
-                     specified timestamp of observation. It contains the 
+        Tsysinfo     [dictionary] Contains system temperature information for
+                     specified timestamp of observation. It contains the
                      following keys and values:
-                     'Trx'      [scalar] Recevier temperature (in K) that is 
+                     'Trx'      [scalar] Recevier temperature (in K) that is
                                 applicable to all frequencies and baselines
                      'Tant'     [dictionary] contains antenna temperature info
-                                from which the antenna temperature is estimated. 
-                                Used only if the key 'Tnet' is absent or set to 
+                                from which the antenna temperature is estimated.
+                                Used only if the key 'Tnet' is absent or set to
                                 None. It has the following keys and values:
-                                'f0'      [scalar] Reference frequency (in Hz) 
-                                          from which antenna temperature will 
+                                'f0'      [scalar] Reference frequency (in Hz)
+                                          from which antenna temperature will
                                           be estimated (see formula below)
                                 'T0'      [scalar] Antenna temperature (in K) at
-                                          the reference frequency specified in 
+                                          the reference frequency specified in
                                           key 'f0'. See formula below.
                                 'spindex' [scalar] Antenna temperature spectral
                                           index. See formula below.
 
                                 Tsys = Trx + Tant['T0'] * (f/Tant['f0'])**spindex
 
-                     'Tnet'     [numpy array] Pre-computed Tsys (in K) 
+                     'Tnet'     [numpy array] Pre-computed Tsys (in K)
                                 information that will be used directly to set the
-                                Tsys. If specified, the information under keys 
-                                'Trx' and 'Tant' will be ignored. If a scalar 
-                                value is provided, it will be assumed to be 
-                                identical for all interferometers and all 
-                                frequencies. If a vector is provided whose length 
-                                is equal to the number of interferoemters, it 
-                                will be assumed identical for all frequencies. If 
-                                a vector is provided whose length is equal to the 
-                                number of frequency channels, it will be assumed 
-                                identical for all interferometers. If a 2D array 
-                                is provided, it should be of size 
+                                Tsys. If specified, the information under keys
+                                'Trx' and 'Tant' will be ignored. If a scalar
+                                value is provided, it will be assumed to be
+                                identical for all interferometers and all
+                                frequencies. If a vector is provided whose length
+                                is equal to the number of interferoemters, it
+                                will be assumed identical for all frequencies. If
+                                a vector is provided whose length is equal to the
+                                number of frequency channels, it will be assumed
+                                identical for all interferometers. If a 2D array
+                                is provided, it should be of size
                                 n_baselines x nchan. Tsys = Tnet
 
-        bandpass     [numpy array] Bandpass weights associated with the 
+        bandpass     [numpy array] Bandpass weights associated with the
                      interferometers for the specified timestamp of observation
 
         pointing_center
-                     [2-element numpy vector or list] Pointing center (latitude 
-                     and longitude) of the observation at a given timestamp. 
-                     This is where the telescopes will be phased up to as 
-                     reference. Coordinate system for the pointing_center is 
+                     [2-element numpy vector or list] Pointing center (latitude
+                     and longitude) of the observation at a given timestamp.
+                     This is where the telescopes will be phased up to as
+                     reference. Coordinate system for the pointing_center is
                      specified by the attribute pointing_coords initialized in
-                     __init__(). 
+                     __init__().
 
         skymodel     [instance of class SkyModel] It consists of source flux
-                     densities, their positions, and spectral indices. Read 
+                     densities, their positions, and spectral indices. Read
                      class SkyModel docstring for more information.
 
         t_acc        [scalar] Accumulation time (sec) corresponding to timestamp
 
         brightness_units
-                     [string] Units of flux density in the catalog and for the 
-                     generated visibilities. Accepted values are 'Jy' (Jansky) 
-                     and 'K' (Kelvin for temperature). If None set, it defaults 
+                     [string] Units of flux density in the catalog and for the
+                     generated visibilities. Accepted values are 'Jy' (Jansky)
+                     and 'K' (Kelvin for temperature). If None set, it defaults
                      to 'Jy'
 
         Keyword Inputs:
@@ -4845,22 +4845,22 @@ class InterferometerArray(object):
                      in the polskymodel object, polarized beams for different
                      baseline types for every time stamp that will be simulated
 
-        roi_radius   [scalar] Radius of the region of interest (degrees) inside 
-                     which sources are to be observed. Default = 90 degrees, 
+        roi_radius   [scalar] Radius of the region of interest (degrees) inside
+                     which sources are to be observed. Default = 90 degrees,
                      which is the entire horizon.
 
         roi_center   [string] Center of the region of interest around which
                      roi_radius is used. Accepted values are 'pointing_center'
-                     and 'zenith'. If set to None, it defaults to 'zenith'. 
+                     and 'zenith'. If set to None, it defaults to 'zenith'.
 
         lst          [scalar] LST (in degrees) associated with the timestamp
 
         gradient_mode
-                     [string] If set to None, visibilities will be simulated as 
-                     usual. If set to string, both visibilities and visibility 
-                     gradients with respect to the quantity specified in the 
-                     string will be simulated. Currently accepted value is 
-                     'baseline'. Plan to incorporate gradients with respect to 
+                     [string] If set to None, visibilities will be simulated as
+                     usual. If set to string, both visibilities and visibility
+                     gradients with respect to the quantity specified in the
+                     string will be simulated. Currently accepted value is
+                     'baseline'. Plan to incorporate gradients with respect to
                      'skypos' and 'frequency' as well in the future.
 
         memsave      [boolean] If set to True, enforce computations in single
@@ -4933,7 +4933,7 @@ class InterferometerArray(object):
         if isinstance(Tsys, (int,float)):
             if Tsys < 0.0:
                 raise ValueError('Tsys found to be negative.')
-            
+
             if len(self.Tsys.shape) == 2:
                 self.Tsys = Tsys + NP.zeros((self.baselines.shape[0], self.channels.size, 1))
             else:
@@ -5071,12 +5071,12 @@ class InterferometerArray(object):
         else:
             if roi_radius is None:
                 roi_radius = 90.0
-    
+
             if roi_center is None:
                 roi_center = 'zenith'
             elif (roi_center != 'zenith') and (roi_center != 'pointing_center'):
                 raise ValueError('Center of region of interest, roi_center, must be set to "zenith" or "pointing_center".')
-    
+
             if roi_center == 'pointing_center':
                 m1, m2, d12 = GEOM.spherematch(pointing_lon, pointing_lat, skymodel.location[:,0], skymodel.location[:,1], roi_radius, maxmatches=0)
             else: # roi_center = 'zenith'
@@ -5110,7 +5110,7 @@ class InterferometerArray(object):
                 skypos_dircos_roi = GEOM.altaz2dircos(skypos_altaz_roi, units='degrees')
                 # projected_spatial_frequencies = NP.sqrt(self.baseline_lengths.reshape(1,-1)**2 - (FCNST.c * geometric_delays)**2) / wl0
                 projected_spatial_frequencies = NP.sqrt(self.baseline_lengths.reshape(1,-1,1)**2 - (FCNST.c * geometric_delays[:,:,NP.newaxis])**2) / wl.reshape(1,1,-1)
-                
+
                 src_FWHM = NP.sqrt(skymodel_subset.src_shape[:,0] * skymodel_subset.src_shape[:,1])
                 src_FWHM_dircos = 2.0 * NP.sin(0.5*NP.radians(src_FWHM)).reshape(-1,1) # assuming the projected baseline is perpendicular to source direction
                 # src_sigma_spatial_frequencies = 2.0 * NP.sqrt(2.0 * NP.log(2.0)) / (2 * NP.pi * src_FWHM_dircos)  # estimate 1
@@ -5122,13 +5122,13 @@ class InterferometerArray(object):
                 # src_FWHM_dircos = NP.sqrt(skypos_dircos_roi[:,2].reshape(-1,1)**2 * dtheta_radial**2 + dtheta_circum**2) / NP.sqrt(2.0) # from 2D error propagation (another approximation to commented expression above for the same quantity). Add in quadrature and divide by sqrt(2) to get radius of error circle
                 # arbitrary_factor_for_src_width = NP.sqrt(2.0) # An arbitrary factor that can be adjusted based on what the longest baseline measures for a source of certain finite width
                 # src_sigma_spatial_frequencies = 2.0 * NP.sqrt(2.0 * NP.log(2.0)) / (2 * NP.pi * src_FWHM_dircos) * arbitrary_factor_for_src_width
-                
+
                 # extended_sources_flag = 1/NP.clip(projected_spatial_frequencies, 0.5, NP.amax(projected_spatial_frequencies)) < src_FWHM_dircos
 
                 vis_wts = NP.ones_like(projected_spatial_frequencies)
                 # vis_wts = NP.exp(-0.5 * (projected_spatial_frequencies/src_sigma_spatial_frequencies)**2)
                 vis_wts = NP.exp(-0.5 * (projected_spatial_frequencies/src_sigma_spatial_frequencies[:,:,NP.newaxis])**2) # nsrc x nbl x nchan
-            
+
             if memsave:
                 pbfluxes = pbfluxes.astype(NP.float32, copy=False)
                 self.geometric_delays = self.geometric_delays + [geometric_delays.astype(NP.float32)]
@@ -5158,7 +5158,7 @@ class InterferometerArray(object):
                         memory_required = 3 * len(m2) * self.channels.size * self.baselines.shape[0] * 4.0 * 2 # bytes, 4 bytes per float, factor 2 is because the phase involves complex values, factor 3 because of three vector components of the gradient
                     else:
                         memory_required = 3 * len(m2) * self.channels.size * self.baselines.shape[0] * 8.0 * 2 # bytes, 8 bytes per float, factor 2 is because the phase involves complex values, factor 3 because of three vector components of the gradient
-    
+
             if float(memory_available) > memory_required:
                 if memsave:
                     phase_matrix = NP.exp(-1j * NP.asarray(2.0 * NP.pi).astype(NP.float32) *  (self.geometric_delays[-1][:,:,NP.newaxis].astype(NP.float32) - pc_delay_offsets.astype(NP.float32).reshape(1,-1,1)) * self.channels.astype(NP.float32).reshape(1,1,-1)).astype(NP.complex64)
@@ -5194,7 +5194,7 @@ class InterferometerArray(object):
                         if vis_wts is not None:
                             phase_matrix *= vis_wts[src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),:,:].astype(NP.float32)
                             # phase_matrix *= vis_wts[src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),:,NP.newaxis].astype(NP.float32)
-                            
+
                         phase_matrix *= pbfluxes[src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),NP.newaxis,:].astype(NP.float32)
                         skyvis += NP.sum(phase_matrix, axis=0)
                         if gradient_mode is not None:
@@ -5205,7 +5205,7 @@ class InterferometerArray(object):
                         phase_matrix = NP.exp(-1j * NP.asarray(2.0 * NP.pi).astype(NP.float64) * (self.geometric_delays[-1][src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),:,NP.newaxis].astype(NP.float64) - pc_delay_offsets.astype(NP.float64).reshape(1,-1,1)) * self.channels.astype(NP.float64).reshape(1,1,-1)).astype(NP.complex128, copy=False)
                         if vis_wts is not None:
                             phase_matrix *= vis_wts[src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),:,:].astype(NP.float64)
-                            
+
                         phase_matrix *= pbfluxes[src_indices[i]:min(src_indices[i]+n_src_stepsize,len(m2)),NP.newaxis,:].astype(NP.float64)
                         skyvis += NP.sum(phase_matrix, axis=0)
                         if gradient_mode is not None:
@@ -5237,7 +5237,7 @@ class InterferometerArray(object):
 
     ############################################################################
 
-    def observing_run(self, pointing_init, skymodel, t_acc, duration, channels, 
+    def observing_run(self, pointing_init, skymodel, t_acc, duration, channels,
                       bpass, Tsys, lst_init, roi_radius=None, roi_center=None,
                       mode='track', pointing_coords=None, freq_scale=None,
                       brightness_units=None, verbose=True, memsave=False):
@@ -5245,35 +5245,35 @@ class InterferometerArray(object):
         """
         -------------------------------------------------------------------------
         Simulate an extended observing run in 'track' or 'drift' mode, by an
-        instance of the InterferometerArray class, of the sky when a sky catalog 
+        instance of the InterferometerArray class, of the sky when a sky catalog
         is provided. The simulation generates visibilities observed by the
         interferometer array for the specified parameters. Uses member function
         observe() and builds the observation from snapshots. The timestamp for
         each snapshot is the current time at which the snapshot is generated.
 
         Inputs:
-        
+
         pointing_init [2-element list or numpy array] The inital pointing
-                      of the telescope at the start of the observing run. 
+                      of the telescope at the start of the observing run.
                       This is where the telescopes will be initially phased up to
-                      as reference. Coordinate system for the pointing_center is 
-                      specified by the input pointing_coords 
+                      as reference. Coordinate system for the pointing_center is
+                      specified by the input pointing_coords
 
         skymodel      [instance of class SkyModel] It consists of source flux
-                      densities, their positions, and spectral indices. Read 
+                      densities, their positions, and spectral indices. Read
                       class SkyModel docstring for more information.
 
         t_acc         [scalar] Accumulation time (sec) corresponding to timestamp
 
         brightness_units
-                      [string] Units of flux density in the catalog and for the 
-                      generated visibilities. Accepted values are 'Jy' (Jansky) 
-                      and 'K' (Kelvin for temperature). If None set, it defaults 
+                      [string] Units of flux density in the catalog and for the
+                      generated visibilities. Accepted values are 'Jy' (Jansky)
+                      and 'K' (Kelvin for temperature). If None set, it defaults
                       to 'Jy'
 
         duration      [scalar] Duration of observation in seconds
 
-        channels      [list or numpy vector] frequency channels in units as 
+        channels      [list or numpy vector] frequency channels in units as
                       specified in freq_scale
 
         bpass         [list, list of lists or numpy array] Bandpass weights in
@@ -5286,40 +5286,40 @@ class InterferometerArray(object):
         Tsys          [scalar, list or numpy array] System temperature (in K). If
                       a scalar is provided, the same Tsys will be used in all the
                       snapshots for the duration of the observation. If a list or
-                      numpy array is provided, the number of elements must equal 
+                      numpy array is provided, the number of elements must equal
                       the number of snapshots which is int(duration/t_int)
 
-        lst_init      [scalar] Initial LST (in degrees) at the beginning of the 
+        lst_init      [scalar] Initial LST (in degrees) at the beginning of the
                       observing run corresponding to pointing_init
 
         Keyword Inputs:
 
-        roi_radius    [scalar] Radius of the region of interest (degrees) inside 
-                      which sources are to be observed. Default = 90 degrees, 
+        roi_radius    [scalar] Radius of the region of interest (degrees) inside
+                      which sources are to be observed. Default = 90 degrees,
                       which is the entire horizon.
-                      
+
         roi_center    [string] Center of the region of interest around which
                       roi_radius is used. Accepted values are 'pointing_center'
-                      and 'zenith'. If set to None, it defaults to 'zenith'. 
+                      and 'zenith'. If set to None, it defaults to 'zenith'.
 
-        freq_scale    [string] Units of frequencies specified in channels. 
+        freq_scale    [string] Units of frequencies specified in channels.
                       Accepted values are 'Hz', 'hz', 'khz', 'kHz', 'mhz',
                       'MHz', 'GHz' and 'ghz'. If None provided, defaults to 'Hz'
 
         mode          [string] Mode of observation. Accepted values are 'track'
                       and 'drift'. If using 'track', pointing center is fixed to
-                      a specific point on the sky coordinate frame. If using 
+                      a specific point on the sky coordinate frame. If using
                       'drift', pointing center is fixed to a specific point on
-                      the antenna's reference frame. 
+                      the antenna's reference frame.
 
         pointing_coords
-                      [string] Coordinate system for pointing_init. Accepted 
+                      [string] Coordinate system for pointing_init. Accepted
                       values are 'radec', 'hadec' and 'altaz'. If None provided,
-                      default is set based on observing mode. If mode='track', 
-                      pointing_coords defaults to 'radec', and if mode='drift', 
+                      default is set based on observing mode. If mode='track',
+                      pointing_coords defaults to 'radec', and if mode='drift',
                       it defaults to 'hadec'
 
-        verbose       [boolean] If set to True, prints progress and diagnostic 
+        verbose       [boolean] If set to True, prints progress and diagnostic
                       messages. Default = True
         ------------------------------------------------------------------------
         """
@@ -5383,7 +5383,7 @@ class InterferometerArray(object):
             bpass = NP.asarray(bpass)
         else:
             raise TypeError('bpass must be a list, tuple or numpy array')
-        
+
         if bpass.size == self.channels.size:
             bpass = NP.expand_dims(NP.repeat(bpass.reshape(1,-1), self.baselines.shape[0], axis=0), axis=2)
             if verbose:
@@ -5401,7 +5401,7 @@ class InterferometerArray(object):
             Tsys = NP.asarray(Tsys).reshape(-1)
         else:
             raise TypeError('Tsys must be a scalar, list, tuple or numpy array')
-        
+
         if Tsys.size == 1:
             if verbose:
                 print '\t\tTsys = {0:.1f} K will be assumed for all frequencies, baselines, and accumulations.'.format(Tsys[0])
@@ -5460,7 +5460,7 @@ class InterferometerArray(object):
 
         if verbose:
             print '\tPreparing to observe in {0} mode'.format(mode)
-            
+
         if verbose:
             milestones = range(max(1,int(n_acc/10)), int(n_acc), max(1,int(n_acc/10)))
             progress = PGB.ProgressBar(widgets=[PGB.Percentage(), PGB.Bar(), PGB.ETA()], maxval=n_acc).start()
@@ -5490,10 +5490,10 @@ class InterferometerArray(object):
     #############################################################################
 
     def generate_noise(self):
-        
+
         """
         -------------------------------------------------------------------------
-        Generates thermal noise from attributes that describe system parameters 
+        Generates thermal noise from attributes that describe system parameters
         which can be added to sky visibilities
         -------------------------------------------------------------------------
         """
@@ -5528,7 +5528,7 @@ class InterferometerArray(object):
         gains
         -------------------------------------------------------------------------
         """
-        
+
         gains = 1.0
         if self.gaininfo is not None:
             try:
@@ -5543,7 +5543,7 @@ class InterferometerArray(object):
                         warnings.warn('Interpolation and nearest neighbour logic failed. Proceeding with default unity gains')
         else:
             warnings.warn('Gain table absent. Proceeding with default unity gains')
-                
+
         self.vis_freq = gains * self.skyvis_freq + self.vis_noise_freq
 
     #############################################################################
@@ -5554,29 +5554,29 @@ class InterferometerArray(object):
         """
         -------------------------------------------------------------------------
         Centers the phase of visibilities around any given phase center.
-        Project baseline vectors with respect to a reference point on the sky. 
-        Essentially a wrapper to member functions phase_centering() and 
+        Project baseline vectors with respect to a reference point on the sky.
+        Essentially a wrapper to member functions phase_centering() and
         project_baselines()
 
         Input(s):
 
-        ref_point   [dictionary] Contains information about the reference 
-                    position to which projected baselines and rotated 
-                    visibilities are to be computed. No defaults. It must be 
+        ref_point   [dictionary] Contains information about the reference
+                    position to which projected baselines and rotated
+                    visibilities are to be computed. No defaults. It must be
                     contain the following keys with the following values:
                     'coords'    [string] Refers to the coordinate system in
-                                which value in key 'location' is specified in. 
+                                which value in key 'location' is specified in.
                                 Accepted values are 'radec', 'hadec', 'altaz'
                                 and 'dircos'
-                    'location'  [numpy array] Must be a Mx2 (if value in key 
+                    'location'  [numpy array] Must be a Mx2 (if value in key
                                 'coords' is set to 'radec', 'hadec', 'altaz' or
-                                'dircos') or Mx3 (if value in key 'coords' is 
+                                'dircos') or Mx3 (if value in key 'coords' is
                                 set to 'dircos'). M can be 1 or equal to number
                                 of timestamps. If M=1, the same reference point
-                                in the same coordinate system will be repeated 
+                                in the same coordinate system will be repeated
                                 for all tiemstamps. If value under key 'coords'
-                                is set to 'radec', 'hadec' or 'altaz', the 
-                                value under this key 'location' must be in 
+                                is set to 'radec', 'hadec' or 'altaz', the
+                                value under this key 'location' must be in
                                 units of degrees.
 
         do_delay_transform
@@ -5588,7 +5588,7 @@ class InterferometerArray(object):
                       diagnostic messages.
         -------------------------------------------------------------------------
         """
-        
+
         try:
             ref_point
         except NameError:
@@ -5612,29 +5612,29 @@ class InterferometerArray(object):
         Centers the phase of visibilities around any given phase center.
 
         Inputs:
-        
-        ref_point   [dictionary] Contains information about the reference 
-                    position to which projected baselines and rotated 
-                    visibilities are to be computed. No defaults. It must be 
+
+        ref_point   [dictionary] Contains information about the reference
+                    position to which projected baselines and rotated
+                    visibilities are to be computed. No defaults. It must be
                     contain the following keys with the following values:
                     'coords'    [string] Refers to the coordinate system in
-                                which value in key 'location' is specified in. 
+                                which value in key 'location' is specified in.
                                 Accepted values are 'radec', 'hadec', 'altaz'
                                 and 'dircos'
-                    'location'  [numpy array] Must be a Mx2 (if value in key 
+                    'location'  [numpy array] Must be a Mx2 (if value in key
                                 'coords' is set to 'radec', 'hadec', 'altaz' or
-                                'dircos') or Mx3 (if value in key 'coords' is 
+                                'dircos') or Mx3 (if value in key 'coords' is
                                 set to 'dircos'). M can be 1 or equal to number
                                 of timestamps. If M=1, the same reference point
-                                in the same coordinate system will be repeated 
+                                in the same coordinate system will be repeated
                                 for all tiemstamps. If value under key 'coords'
-                                is set to 'radec', 'hadec' or 'altaz', the 
-                                value under this key 'location' must be in 
+                                is set to 'radec', 'hadec' or 'altaz', the
+                                value under this key 'location' must be in
                                 units of degrees.
 
         do_delay_transform
-                      [boolean] If set to True, also recompute the delay 
-                      transform after the visibilities are rotated to the new 
+                      [boolean] If set to True, also recompute the delay
+                      transform after the visibilities are rotated to the new
                       phase center. If set to False (default), this is skipped
 
         verbose:      [boolean] If set to True (default), prints progress and
@@ -5764,7 +5764,7 @@ class InterferometerArray(object):
             phase_center_current_temp = GEOM.altaz2dircos(phase_center_current_temp, units='degrees')
             phase_center_coords_current_temp = 'dircos'
 
-        pos_diff_dircos = phase_center_current_temp - phase_center_new 
+        pos_diff_dircos = phase_center_current_temp - phase_center_new
         b_dot_l = NP.dot(self.baselines, pos_diff_dircos.T)
 
         self.phase_center = phase_center_temp + 0.0
@@ -5785,28 +5785,28 @@ class InterferometerArray(object):
 
         """
         ------------------------------------------------------------------------
-        Project baseline vectors with respect to a reference point on the sky. 
+        Project baseline vectors with respect to a reference point on the sky.
         Assigns the projected baselines to the attribute projected_baselines
 
         Input(s):
 
-        ref_point   [dictionary] Contains information about the reference 
-                    position to which projected baselines are to be computed. 
-                    No defaults. It must be contain the following keys with the 
+        ref_point   [dictionary] Contains information about the reference
+                    position to which projected baselines are to be computed.
+                    No defaults. It must be contain the following keys with the
                     following values:
                     'coords'    [string] Refers to the coordinate system in
-                                which value in key 'location' is specified in. 
+                                which value in key 'location' is specified in.
                                 Accepted values are 'radec', 'hadec', 'altaz'
                                 and 'dircos'
-                    'location'  [numpy array] Must be a Mx2 (if value in key 
+                    'location'  [numpy array] Must be a Mx2 (if value in key
                                 'coords' is set to 'radec', 'hadec', 'altaz' or
-                                'dircos') or Mx3 (if value in key 'coords' is 
+                                'dircos') or Mx3 (if value in key 'coords' is
                                 set to 'dircos'). M can be 1 or equal to number
                                 of timestamps. If M=1, the same reference point
-                                in the same coordinate system will be repeated 
+                                in the same coordinate system will be repeated
                                 for all tiemstamps. If value under key 'coords'
-                                is set to 'radec', 'hadec' or 'altaz', the 
-                                value under this key 'location' must be in 
+                                is set to 'radec', 'hadec' or 'altaz', the
+                                value under this key 'location' must be in
                                 units of degrees.
         ------------------------------------------------------------------------
         """
@@ -5874,16 +5874,16 @@ class InterferometerArray(object):
 
         eq_baselines = GEOM.enu2xyz(self.baselines, self.latitude, units='degrees')
         rot_matrix = NP.asarray([[NP.sin(ha),               NP.cos(ha),             NP.zeros(ha.size)],
-                                 [-NP.sin(dec)*NP.cos(ha), NP.sin(dec)*NP.sin(ha), NP.cos(dec)], 
+                                 [-NP.sin(dec)*NP.cos(ha), NP.sin(dec)*NP.sin(ha), NP.cos(dec)],
                                  [NP.cos(dec)*NP.cos(ha), -NP.cos(dec)*NP.sin(ha), NP.sin(dec)]])
         if rot_matrix.ndim == 2:
             rot_matrix = rot_matrix[:,:,NP.newaxis] # To ensure correct dot product is obtained in the next step
-        self.projected_baselines = NP.dot(eq_baselines, rot_matrix) # (n_bl x [3]).(3 x [3] x n_acc) -> n_bl x (first 3) x n_acc 
+        self.projected_baselines = NP.dot(eq_baselines, rot_matrix) # (n_bl x [3]).(3 x [3] x n_acc) -> n_bl x (first 3) x n_acc
 
         # proj_baselines = NP.empty((eq_baselines.shape[0], eq_baselines.shape[1], len(self.lst)))
         # for i in xrange(len(self.lst)):
         #     rot_matrix = NP.asarray([[NP.sin(ha[i]),               NP.cos(ha[i]),             0.0],
-        #                              [-NP.sin(dec[i])*NP.cos(ha[i]), NP.sin(dec[i])*NP.sin(ha[i]), NP.cos(dec[i])], 
+        #                              [-NP.sin(dec[i])*NP.cos(ha[i]), NP.sin(dec[i])*NP.sin(ha[i]), NP.cos(dec[i])],
         #                              [NP.cos(dec[i])*NP.cos(ha[i]), -NP.cos(dec[i])*NP.sin(ha[i]), NP.sin(dec[i])]])
 
         #     proj_baselines[:,:,i] = NP.dot(eq_baselines, rot_matrix.T)
@@ -5903,10 +5903,10 @@ class InterferometerArray(object):
 
         ind      [scalar, list or numpy array] Indices pointing to specific
                  baseline vectors which need to be flipped. Default = None means
-                 no flipping or conjugation. If all baselines are to be 
+                 no flipping or conjugation. If all baselines are to be
                  flipped, either provide all the indices in ind or set ind="all"
 
-        verbose  [boolean] If set to True (default), print diagnostic and 
+        verbose  [boolean] If set to True (default), print diagnostic and
                  progress messages. If set to False, no such messages are
                  printed.
         ------------------------------------------------------------------------
@@ -5923,7 +5923,7 @@ class InterferometerArray(object):
                 ind = ind.tolist()
             elif not isinstance(ind, list):
                 raise TypeError('ind must be string "all", scalar interger, list or numpy array')
-                
+
             ind = NP.asarray(ind)
             if NP.any(ind >= self.baselines.shape[0]):
                 raise IndexError('Out of range indices found.')
@@ -5938,7 +5938,7 @@ class InterferometerArray(object):
             if self.vis_noise_freq is not None:
                 self.vis_noise_freq[ind,:,:] = self.vis_noise_freq[ind,:,:].conj()
             if self.projected_baselines is not None:
-                self.projected_baselines[ind,:,:] = -self.projected_baselines[ind,:,:] 
+                self.projected_baselines[ind,:,:] = -self.projected_baselines[ind,:,:]
 
             if verbose:
                 print 'Certain baselines have been flipped and their visibilities conjugated. Use delay_transform() to update the delay spectra.'
@@ -5951,29 +5951,29 @@ class InterferometerArray(object):
         ------------------------------------------------------------------------
         Transforms the visibilities from frequency axis onto delay (time) axis
         using an IFFT. This is performed for noiseless sky visibilities, thermal
-        noise in visibilities, and observed visibilities. 
+        noise in visibilities, and observed visibilities.
 
         Inputs:
 
-        pad         [scalar] Non-negative scalar indicating padding fraction 
-                    relative to the number of frequency channels. For e.g., a 
-                    pad of 1.0 pads the frequency axis with zeros of the same 
+        pad         [scalar] Non-negative scalar indicating padding fraction
+                    relative to the number of frequency channels. For e.g., a
+                    pad of 1.0 pads the frequency axis with zeros of the same
                     width as the number of channels. After the delay transform,
                     the transformed visibilities are downsampled by a factor of
-                    1+pad. If a negative value is specified, delay transform 
+                    1+pad. If a negative value is specified, delay transform
                     will be performed with no padding
 
         freq_wts    [numpy vector or array] window shaping to be applied before
                     computing delay transform. It can either be a vector or size
                     equal to the number of channels (which will be applied to all
-                    time instances for all baselines), or a nchan x n_snapshots 
-                    numpy array which will be applied to all baselines, or a 
-                    n_baselines x nchan numpy array which will be applied to all 
-                    timestamps, or a n_baselines x nchan x n_snapshots numpy 
+                    time instances for all baselines), or a nchan x n_snapshots
+                    numpy array which will be applied to all baselines, or a
+                    n_baselines x nchan numpy array which will be applied to all
+                    timestamps, or a n_baselines x nchan x n_snapshots numpy
                     array. Default (None) will not apply windowing and only the
                     inherent bandpass will be used.
 
-        verbose     [boolean] If set to True (default), print diagnostic and 
+        verbose     [boolean] If set to True (default), print diagnostic and
                     progress messages. If set to False, no such messages are
                     printed.
         ------------------------------------------------------------------------
@@ -6006,7 +6006,7 @@ class InterferometerArray(object):
 
         if verbose:
             print '\tInput parameters have been verified to be compatible.\n\tProceeding to compute delay transform.'
-            
+
         self.lags = DSP.spectral_axis(self.channels.size, delx=self.freq_resolution, use_real=False, shift=True)
         if pad == 0.0:
             self.vis_lag = DSP.FT1D(self.vis_freq * self.bp * self.bp_wts, ax=1, inverse=True, use_real=False, shift=True) * self.channels.size * self.freq_resolution
@@ -6044,31 +6044,31 @@ class InterferometerArray(object):
 
         Inputs:
 
-        bw_eff       [scalar, list, numpy array] Effective bandwidths of the 
+        bw_eff       [scalar, list, numpy array] Effective bandwidths of the
                      selected frequency windows. If a scalar is provided, the
                      same will be applied to all frequency windows.
 
         freq_center  [scalar, list, numpy array] Frequency centers of the
                      selected frequency windows. If a scalar is provided, the
                      same will be applied to all frequency windows. Default=None
-                     uses the center frequency from the class attribute named 
+                     uses the center frequency from the class attribute named
                      channels
 
         shape        [string] specifies frequency window shape. Accepted values
-                     are 'rect' or 'RECT' (for rectangular), 'bnw' and 'BNW' 
+                     are 'rect' or 'RECT' (for rectangular), 'bnw' and 'BNW'
                      (for Blackman-Nuttall), and 'bhw' or 'BHW' (for Blackman-
-                     Harris). Default=None sets it to 'rect' (rectangular 
+                     Harris). Default=None sets it to 'rect' (rectangular
                      window)
 
-        pad          [scalar] Non-negative scalar indicating padding fraction 
-                     relative to the number of frequency channels. For e.g., a 
-                     pad of 1.0 pads the frequency axis with zeros of the same 
+        pad          [scalar] Non-negative scalar indicating padding fraction
+                     relative to the number of frequency channels. For e.g., a
+                     pad of 1.0 pads the frequency axis with zeros of the same
                      width as the number of channels. After the delay transform,
                      the transformed visibilities are downsampled by a factor of
-                     1+pad. If a negative value is specified, delay transform 
+                     1+pad. If a negative value is specified, delay transform
                      will be performed with no padding
 
-        verbose      [boolean] If set to True (default), print diagnostic and 
+        verbose      [boolean] If set to True (default), print diagnostic and
                      progress messages. If set to False, no such messages are
                      printed.
 
@@ -6179,7 +6179,7 @@ class InterferometerArray(object):
             if verbose:
                 print '\tMulti-window delay transform products downsampled by factor of {0:.1f}'.format(1+pad)
                 print 'multi_window_delay_transform() completed successfully.'
-                
+
         return {'skyvis_lag': skyvis_lag, 'vis_noise_lag': vis_noise_lag, 'lag_kernel': lag_kernel, 'lag_corr_length': self.channels.size / NP.sum(freq_wts, axis=1)}
 
     #############################################################################
@@ -6193,14 +6193,14 @@ class InterferometerArray(object):
 
         Inputs:
 
-        others       [instance of class Interferometer Array or list of such 
+        others       [instance of class Interferometer Array or list of such
                      instances] Instance or list of instances of class
-                     InterferometerArray whose visibility data have to be 
+                     InterferometerArray whose visibility data have to be
                      concatenated to the current instance.
 
         axis         [scalar] Axis along which visibility data sets are to be
                      concatenated. Accepted values are 0 (concatenate along
-                     baseline axis), 1 (concatenate frequency channels), or 2 
+                     baseline axis), 1 (concatenate frequency channels), or 2
                      (concatenate along time/snapshot axis). No default
         -------------------------------------------------------------------------
         """
@@ -6219,7 +6219,7 @@ class InterferometerArray(object):
             loo = [self, others]
         elif not isinstance(other, InterferometerArray):
             raise TypeError('The interferometer array data to be concatenated must be an instance of class InterferometerArray or a list of such instances')
-            
+
         if not isinstance(axis, int):
             raise TypeError('axis must be an integer')
 
@@ -6291,82 +6291,82 @@ class InterferometerArray(object):
 
         """
         -------------------------------------------------------------------------
-        Saves the interferometer array information to disk in HDF5, FITS, NPZ 
+        Saves the interferometer array information to disk in HDF5, FITS, NPZ
         and UVFITS formats
 
         Inputs:
 
         outfile      [string] Filename with full path to be saved to. Will be
-                     appended with '.hdf5' or '.fits' extension depending on 
-                     input keyword fmt. If input npz is set to True, the 
-                     simulated visibilities will also get stored in '.npz' 
-                     format. Depending on parameters in uvfits_parms, three 
-                     UVFITS files will also be created whose names will be 
-                     outfile+'-noiseless', outfile+'-noisy' and 
+                     appended with '.hdf5' or '.fits' extension depending on
+                     input keyword fmt. If input npz is set to True, the
+                     simulated visibilities will also get stored in '.npz'
+                     format. Depending on parameters in uvfits_parms, three
+                     UVFITS files will also be created whose names will be
+                     outfile+'-noiseless', outfile+'-noisy' and
                      'outfile+'-noise' appended with '.uvfits'
 
         Keyword Input(s):
 
-        fmt          [string] string specifying the format of the output. 
-                     Accepted values are 'HDF5' (default) and 'FITS'. 
+        fmt          [string] string specifying the format of the output.
+                     Accepted values are 'HDF5' (default) and 'FITS'.
                      The file names will be appended with '.hdf5' or '.fits'
                      respectively
 
-        tabtype      [string] indicates table type for one of the extensions in 
-                     the FITS file. Allowed values are 'BinTableHDU' and 
-                     'TableHDU' for binary and ascii tables respectively. Default 
+        tabtype      [string] indicates table type for one of the extensions in
+                     the FITS file. Allowed values are 'BinTableHDU' and
+                     'TableHDU' for binary and ascii tables respectively. Default
                      is 'BinTableHDU'. Only applies if input fmt is set to 'FITS'
 
         npz          [boolean] True (default) indicates a numpy NPZ format file
                      is created in addition to the FITS file to store essential
-                     attributes of the class InterferometerArray for easy 
+                     attributes of the class InterferometerArray for easy
                      handing over of python files
-                     
-        overwrite    [boolean] True indicates overwrite even if a file already 
-                     exists. Default = False (does not overwrite). Beware this 
-                     may not work reliably for UVFITS output when uvfits_method 
-                     is set to None or 'uvdata' and hence always better to make 
+
+        overwrite    [boolean] True indicates overwrite even if a file already
+                     exists. Default = False (does not overwrite). Beware this
+                     may not work reliably for UVFITS output when uvfits_method
+                     is set to None or 'uvdata' and hence always better to make
                      sure the output file does not exist already
-                     
-        uvfits_parms [dictionary] specifies basic parameters required for 
+
+        uvfits_parms [dictionary] specifies basic parameters required for
                      saving in UVFITS format. If set to None (default), the
-                     data will not be saved in UVFITS format. To save in UVFITS 
+                     data will not be saved in UVFITS format. To save in UVFITS
                      format, the following keys and values are required:
-                     'ref_point'    [dictionary] Contains information about the 
-                                    reference position to which projected 
-                                    baselines and rotated visibilities are to 
-                                    be computed. Default=None (no additional 
-                                    phasing will be performed). It must be 
-                                    contain the following keys with the 
+                     'ref_point'    [dictionary] Contains information about the
+                                    reference position to which projected
+                                    baselines and rotated visibilities are to
+                                    be computed. Default=None (no additional
+                                    phasing will be performed). It must be
+                                    contain the following keys with the
                                     following values:
-                                    'coords'    [string] Refers to the 
-                                                coordinate system in which value 
-                                                in key 'location' is specified 
-                                                in. Accepted values are 'radec', 
+                                    'coords'    [string] Refers to the
+                                                coordinate system in which value
+                                                in key 'location' is specified
+                                                in. Accepted values are 'radec',
                                                 'hadec', 'altaz' and 'dircos'
-                                    'location'  [numpy array] Must be a Mx2 (if 
-                                                value in key 'coords' is set to 
-                                                'radec', 'hadec', 'altaz' or 
-                                                'dircos') or Mx3 (if value in 
-                                                key 'coords' is set to 
-                                                'dircos'). M can be 1 or equal 
-                                                to number of timestamps. If M=1, 
-                                                the same reference point in the 
-                                                same coordinate system will be 
-                                                repeated for all tiemstamps. If 
-                                                value under key 'coords' is set 
-                                                to 'radec', 'hadec' or 'altaz', 
-                                                the value under this key 
-                                                'location' must be in units of 
+                                    'location'  [numpy array] Must be a Mx2 (if
+                                                value in key 'coords' is set to
+                                                'radec', 'hadec', 'altaz' or
+                                                'dircos') or Mx3 (if value in
+                                                key 'coords' is set to
+                                                'dircos'). M can be 1 or equal
+                                                to number of timestamps. If M=1,
+                                                the same reference point in the
+                                                same coordinate system will be
+                                                repeated for all tiemstamps. If
+                                                value under key 'coords' is set
+                                                to 'radec', 'hadec' or 'altaz',
+                                                the value under this key
+                                                'location' must be in units of
                                                 degrees.
-                     'method'       [string] specifies method to be used in 
-                                    saving in UVFITS format. Accepted values are 
-                                    'uvdata', 'uvfits' or None (default). If set 
-                                    to 'uvdata', the UVFITS writer in uvdata 
-                                    module is used. If set to 'uvfits', the 
-                                    in-house UVFITS writer is used. If set to 
-                                    None, first uvdata module will be attempted 
-                                    but if it fails then the in-house UVFITS 
+                     'method'       [string] specifies method to be used in
+                                    saving in UVFITS format. Accepted values are
+                                    'uvdata', 'uvfits' or None (default). If set
+                                    to 'uvdata', the UVFITS writer in uvdata
+                                    module is used. If set to 'uvfits', the
+                                    in-house UVFITS writer is used. If set to
+                                    None, first uvdata module will be attempted
+                                    but if it fails then the in-house UVFITS
                                     writer will be tried.
 
         verbose      [boolean] If True (default), prints diagnostic and progress
@@ -6393,13 +6393,13 @@ class InterferometerArray(object):
             use_ascii = False
             if tabtype == 'TableHDU':
                 use_ascii = True
-    
+
             hdulist = []
-    
+
             hdulist += [fits.PrimaryHDU()]
             hdulist[0].header['latitude'] = (self.latitude, 'Latitude of interferometer')
-            hdulist[0].header['longitude'] = (self.longitude, 'Longitude of interferometer')        
-            hdulist[0].header['altitude'] = (self.altitude, 'Altitude of interferometer')        
+            hdulist[0].header['longitude'] = (self.longitude, 'Longitude of interferometer')
+            hdulist[0].header['altitude'] = (self.altitude, 'Altitude of interferometer')
             hdulist[0].header['baseline_coords'] = (self.baseline_coords, 'Baseline coordinate system')
             hdulist[0].header['freq_resolution'] = (self.freq_resolution, 'Frequency Resolution (Hz)')
             hdulist[0].header['pointing_coords'] = (self.pointing_coords, 'Pointing coordinate system')
@@ -6419,58 +6419,58 @@ class InterferometerArray(object):
             hdulist[0].header['element_size'] = (self.telescope['size'], 'Antenna element size')
             hdulist[0].header['element_ocoords'] = (self.telescope['ocoords'], 'Antenna element orientation coordinates')
             hdulist[0].header['t_obs'] = (self.t_obs, 'Observing duration (s)')
-            hdulist[0].header['n_acc'] = (self.n_acc, 'Number of accumulations')        
+            hdulist[0].header['n_acc'] = (self.n_acc, 'Number of accumulations')
             hdulist[0].header['flux_unit'] = (self.flux_unit, 'Unit of flux density')
             hdulist[0].header['EXTNAME'] = 'PRIMARY'
-    
+
             if verbose:
                 print '\tCreated a primary HDU.'
-    
+
             hdulist += [fits.ImageHDU(self.telescope['orientation'], name='Antenna element orientation')]
             if verbose:
                 print '\tCreated an extension for antenna element orientation.'
-    
+
             cols = []
-            if self.lst: 
+            if self.lst:
                 cols += [fits.Column(name='LST', format='D', array=NP.asarray(self.lst).ravel())]
                 cols += [fits.Column(name='pointing_longitude', format='D', array=self.pointing_center[:,0])]
                 cols += [fits.Column(name='pointing_latitude', format='D', array=self.pointing_center[:,1])]
                 cols += [fits.Column(name='phase_center_longitude', format='D', array=self.phase_center[:,0])]
                 cols += [fits.Column(name='phase_center_latitude', format='D', array=self.phase_center[:,1])]
-    
+
             columns = _astropy_columns(cols, tabtype=tabtype)
-    
+
             tbhdu = fits.new_table(columns)
             tbhdu.header.set('EXTNAME', 'POINTING AND PHASE CENTER INFO')
             hdulist += [tbhdu]
             if verbose:
                 print '\tCreated pointing and phase center information table.'
-    
+
             label_lengths = [len(label[0]) for label in self.labels]
             maxlen = max(label_lengths)
             labels = NP.asarray(self.labels, dtype=[('A2', '|S{0:0d}'.format(maxlen)), ('A1', '|S{0:0d}'.format(maxlen))])
             cols = []
             cols += [fits.Column(name='A1', format='{0:0d}A'.format(maxlen), array=labels['A1'])]
-            cols += [fits.Column(name='A2', format='{0:0d}A'.format(maxlen), array=labels['A2'])]        
+            cols += [fits.Column(name='A2', format='{0:0d}A'.format(maxlen), array=labels['A2'])]
             # cols += [fits.Column(name='labels', format='5A', array=NP.asarray(self.labels))]
-    
+
             columns = _astropy_columns(cols, tabtype=tabtype)
-    
+
             tbhdu = fits.new_table(columns)
             tbhdu.header.set('EXTNAME', 'LABELS')
             hdulist += [tbhdu]
             if verbose:
                 print '\tCreated extension table containing baseline labels.'
-    
+
             hdulist += [fits.ImageHDU(self.baselines, name='baselines')]
             if verbose:
                 print '\tCreated an extension for baseline vectors.'
-    
+
             if self.projected_baselines is not None:
                 hdulist += [fits.ImageHDU(self.projected_baselines, name='proj_baselines')]
                 if verbose:
                     print '\tCreated an extension for projected baseline vectors.'
-    
+
             if self.layout:
                 label_lengths = [len(label) for label in self.layout['labels']]
                 maxlen = max(label_lengths)
@@ -6487,29 +6487,29 @@ class InterferometerArray(object):
             hdulist += [fits.ImageHDU(self.A_eff, name='Effective area')]
             if verbose:
                 print '\tCreated an extension for effective area.'
-    
+
             hdulist += [fits.ImageHDU(self.eff_Q, name='Interferometer efficiency')]
             if verbose:
                 print '\tCreated an extension for interferometer efficiency.'
-    
+
             cols = []
             cols += [fits.Column(name='frequency', format='D', array=self.channels)]
             if self.lags is not None:
                 cols += [fits.Column(name='lag', format='D', array=self.lags)]
-    
+
             columns = _astropy_columns(cols, tabtype=tabtype)
-    
+
             tbhdu = fits.new_table(columns)
             tbhdu.header.set('EXTNAME', 'SPECTRAL INFO')
             hdulist += [tbhdu]
             if verbose:
                 print '\tCreated spectral information table.'
-    
+
             if self.t_acc:
                 hdulist += [fits.ImageHDU(self.t_acc, name='t_acc')]
                 if verbose:
                     print '\tCreated an extension for accumulation times.'
-    
+
             cols = []
             if isinstance(self.timestamp[0], str):
                 cols += [fits.Column(name='timestamps', format='24A', array=NP.asarray(self.timestamp))]
@@ -6517,15 +6517,15 @@ class InterferometerArray(object):
                 cols += [fits.Column(name='timestamps', format='D', array=NP.asarray(self.timestamp))]
             else:
                 raise TypeError('Invalid data type for timestamps')
-    
+
             columns = _astropy_columns(cols, tabtype=tabtype)
-    
+
             tbhdu = fits.new_table(columns)
             tbhdu.header.set('EXTNAME', 'TIMESTAMPS')
             hdulist += [tbhdu]
             if verbose:
                 print '\tCreated extension table containing timestamps.'
-    
+
             if self.Tsysinfo:
                 cols = []
                 cols += [fits.Column(name='Trx', format='D', array=NP.asarray([elem['Trx'] for elem in self.Tsysinfo], dtype=NP.float))]
@@ -6536,34 +6536,34 @@ class InterferometerArray(object):
                 tbhdu = fits.new_table(columns)
                 tbhdu.header.set('EXTNAME', 'TSYSINFO')
                 hdulist += [tbhdu]
-    
+
             hdulist += [fits.ImageHDU(self.Tsys, name='Tsys')]
             if verbose:
                 print '\tCreated an extension for Tsys.'
-            
+
             if self.vis_rms_freq is not None:
                 hdulist += [fits.ImageHDU(self.vis_rms_freq, name='freq_channel_noise_rms_visibility')]
                 if verbose:
                     print '\tCreated an extension for simulated visibility noise rms per channel.'
-            
+
             if self.vis_freq is not None:
                 hdulist += [fits.ImageHDU(self.vis_freq.real, name='real_freq_obs_visibility')]
                 hdulist += [fits.ImageHDU(self.vis_freq.imag, name='imag_freq_obs_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of observed visibility frequency spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.vis_freq.shape)
-    
+
             if self.skyvis_freq is not None:
                 hdulist += [fits.ImageHDU(self.skyvis_freq.real, name='real_freq_sky_visibility')]
                 hdulist += [fits.ImageHDU(self.skyvis_freq.imag, name='imag_freq_sky_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of noiseless sky visibility frequency spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.skyvis_freq.shape)
-    
+
             if self.vis_noise_freq is not None:
                 hdulist += [fits.ImageHDU(self.vis_noise_freq.real, name='real_freq_noise_visibility')]
                 hdulist += [fits.ImageHDU(self.vis_noise_freq.imag, name='imag_freq_noise_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of visibility noise frequency spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.vis_noise_freq.shape)
-    
+
             if self.gradient_mode is not None:
                 for gradkey in self.gradient:
                     hdulist += [fits.ImageHDU(self.gradient[gradkey].real, name='real_freq_sky_visibility_gradient_wrt_{0}'.format(gradkey))]
@@ -6574,34 +6574,34 @@ class InterferometerArray(object):
             hdulist += [fits.ImageHDU(self.bp, name='bandpass')]
             if verbose:
                 print '\tCreated an extension for bandpass functions of size {0[0]} x {0[1]} x {0[2]} as a function of baseline,  frequency, and snapshot instance'.format(self.bp.shape)
-    
+
             hdulist += [fits.ImageHDU(self.bp_wts, name='bandpass_weights')]
             if verbose:
                 print '\tCreated an extension for bandpass weights of size {0[0]} x {0[1]} x {0[2]} as a function of baseline,  frequency, and snapshot instance'.format(self.bp_wts.shape)
-    
+
             # hdulist += [fits.ImageHDU(self.lag_kernel.real, name='lag_kernel_real')]
             # hdulist += [fits.ImageHDU(self.lag_kernel.imag, name='lag_kernel_imag')]
             # if verbose:
             #     print '\tCreated an extension for impulse response of frequency bandpass shape of size {0[0]} x {0[1]} x {0[2]} as a function of baseline, lags, and snapshot instance'.format(self.lag_kernel.shape)
-    
+
             if self.vis_lag is not None:
                 hdulist += [fits.ImageHDU(self.vis_lag.real, name='real_lag_visibility')]
                 hdulist += [fits.ImageHDU(self.vis_lag.imag, name='imag_lag_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of observed visibility delay spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.vis_lag.shape)
-    
+
             if self.skyvis_lag is not None:
                 hdulist += [fits.ImageHDU(self.skyvis_lag.real, name='real_lag_sky_visibility')]
                 hdulist += [fits.ImageHDU(self.skyvis_lag.imag, name='imag_lag_sky_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of noiseless sky visibility delay spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.skyvis_lag.shape)
-    
+
             if self.vis_noise_lag is not None:
                 hdulist += [fits.ImageHDU(self.vis_noise_lag.real, name='real_lag_noise_visibility')]
                 hdulist += [fits.ImageHDU(self.vis_noise_lag.imag, name='imag_lag_noise_visibility')]
                 if verbose:
                     print '\tCreated extensions for real and imaginary parts of visibility noise delay spectrum of size {0[0]} x {0[1]} x {0[2]}'.format(self.vis_noise_lag.shape)
-    
+
             if verbose:
                 print '\tNow writing FITS file to disk...'
             hdu = fits.HDUList(hdulist)
@@ -6729,7 +6729,7 @@ class InterferometerArray(object):
                     gains_group = fileobj.create_group('gaininfo')
                     gains_group['gainsfile'] = outfile+'.gains.hdf5'
                     self.gaininfo.write_gaintable(gains_group['gainsfile'].value)
-                                    
+
         if verbose:
             print '\tInterferometer array information written successfully to file on disk:\n\t\t{0}\n'.format(filename)
 
@@ -6746,74 +6746,74 @@ class InterferometerArray(object):
 
     #############################################################################
 
-    def write_uvfits(self, outfile, uvfits_parms=None, overwrite=False, 
+    def write_uvfits(self, outfile, uvfits_parms=None, overwrite=False,
                      verbose=True):
 
         """
         -------------------------------------------------------------------------
-        Saves the interferometer array information to disk in UVFITS format 
+        Saves the interferometer array information to disk in UVFITS format
 
         Inputs:
 
-        outfile      [string] Filename with full path to be saved to. Three 
-                     UVFITS files will also be created whose names will be 
-                     outfile+'-noiseless', outfile+'-noisy' and 
+        outfile      [string] Filename with full path to be saved to. Three
+                     UVFITS files will also be created whose names will be
+                     outfile+'-noiseless', outfile+'-noisy' and
                      'outfile+'-noise' appended with '.uvfits'
 
         Keyword Input(s):
 
-        uvfits_parms [dictionary] specifies basic parameters required for 
+        uvfits_parms [dictionary] specifies basic parameters required for
                      saving in UVFITS format. If set to None (default), the
-                     data will not be saved in UVFITS format. To save in UVFITS 
+                     data will not be saved in UVFITS format. To save in UVFITS
                      format, the following keys and values are required:
-                     'ref_point'    [dictionary] Contains information about the 
-                                    reference position to which projected 
-                                    baselines and rotated visibilities are to 
-                                    be computed. Default=None (no additional 
-                                    phasing will be performed). It must be 
-                                    contain the following keys with the 
+                     'ref_point'    [dictionary] Contains information about the
+                                    reference position to which projected
+                                    baselines and rotated visibilities are to
+                                    be computed. Default=None (no additional
+                                    phasing will be performed). It must be
+                                    contain the following keys with the
                                     following values:
-                                    'coords'    [string] Refers to the 
-                                                coordinate system in which value 
-                                                in key 'location' is specified 
-                                                in. Accepted values are 'radec', 
+                                    'coords'    [string] Refers to the
+                                                coordinate system in which value
+                                                in key 'location' is specified
+                                                in. Accepted values are 'radec',
                                                 'hadec', 'altaz' and 'dircos'
-                                    'location'  [numpy array] Must be a Mx2 (if 
-                                                value in key 'coords' is set to 
-                                                'radec', 'hadec', 'altaz' or 
-                                                'dircos') or Mx3 (if value in 
-                                                key 'coords' is set to 
-                                                'dircos'). M can be 1 or equal 
-                                                to number of timestamps. If M=1, 
-                                                the same reference point in the 
-                                                same coordinate system will be 
-                                                repeated for all tiemstamps. If 
-                                                value under key 'coords' is set 
-                                                to 'radec', 'hadec' or 'altaz', 
-                                                the value under this key 
-                                                'location' must be in units of 
+                                    'location'  [numpy array] Must be a Mx2 (if
+                                                value in key 'coords' is set to
+                                                'radec', 'hadec', 'altaz' or
+                                                'dircos') or Mx3 (if value in
+                                                key 'coords' is set to
+                                                'dircos'). M can be 1 or equal
+                                                to number of timestamps. If M=1,
+                                                the same reference point in the
+                                                same coordinate system will be
+                                                repeated for all tiemstamps. If
+                                                value under key 'coords' is set
+                                                to 'radec', 'hadec' or 'altaz',
+                                                the value under this key
+                                                'location' must be in units of
                                                 degrees.
-                     'method'       [string] specifies method to be used in 
-                                    saving in UVFITS format. Accepted values are 
-                                    'uvdata', 'uvfits' or None (default). If set 
-                                    to 'uvdata', the UVFITS writer in uvdata 
-                                    module is used. If set to 'uvfits', the 
-                                    in-house UVFITS writer is used. If set to 
-                                    None, first uvdata module will be attempted 
-                                    but if it fails then the in-house UVFITS 
+                     'method'       [string] specifies method to be used in
+                                    saving in UVFITS format. Accepted values are
+                                    'uvdata', 'uvfits' or None (default). If set
+                                    to 'uvdata', the UVFITS writer in uvdata
+                                    module is used. If set to 'uvfits', the
+                                    in-house UVFITS writer is used. If set to
+                                    None, first uvdata module will be attempted
+                                    but if it fails then the in-house UVFITS
                                     writer will be tried.
 
-        overwrite    [boolean] True indicates overwrite even if a file already 
-                     exists. Default = False (does not overwrite). Beware this 
+        overwrite    [boolean] True indicates overwrite even if a file already
+                     exists. Default = False (does not overwrite). Beware this
                      may not work reliably if uvfits_method is set to None or
                      'uvdata' and hence always better to make sure the output
                      file does not exist already
-                     
+
         verbose      [boolean] If True (default), prints diagnostic and progress
                      messages. If False, suppress printing such messages.
         -------------------------------------------------------------------------
         """
-                
+
         if uvfits_parms is not None:
             if not isinstance(uvfits_parms, dict):
                 raise TypeError('Input uvfits_parms must be a dictionary')
@@ -6831,13 +6831,13 @@ class ApertureSynthesis(object):
 
     """
     ----------------------------------------------------------------------------
-    Class to manage aperture synthesis of visibility measurements of a 
-    multi-element interferometer array. 
+    Class to manage aperture synthesis of visibility measurements of a
+    multi-element interferometer array.
 
     Attributes:
 
     ia          [instance of class InterferometerArray] Instance of class
-                InterferometerArray created at the time of instantiating an 
+                InterferometerArray created at the time of instantiating an
                 object of class ApertureSynthesis
 
     baselines:  [M x 3 Numpy array] The baseline vectors associated with the
@@ -6848,48 +6848,48 @@ class ApertureSynthesis(object):
                 M interferometers in SI units. The coordinate system of these
                 vectors is X, Y, Z in equatorial coordinates
 
-    uvw_lambda  [M x 3 x Nt numpy array] Baseline vectors phased to the phase 
-                center of each accummulation. M is the number of baselines, Nt 
-                is the number of accumulations and 3 denotes U, V and W 
+    uvw_lambda  [M x 3 x Nt numpy array] Baseline vectors phased to the phase
+                center of each accummulation. M is the number of baselines, Nt
+                is the number of accumulations and 3 denotes U, V and W
                 components. This is in units of physical distance (usually in m)
 
-    uvw         [M x 3 x Nch x Nt numpy array] Baseline vectors phased to the 
-                phase center of each accummulation at each frequency. M is the 
+    uvw         [M x 3 x Nch x Nt numpy array] Baseline vectors phased to the
+                phase center of each accummulation at each frequency. M is the
                 number of baselines, Nt is the number of accumulations, Nch is
-                the number of frequency channels, and 3 denotes U, V and W 
-                components. This is uvw_lambda / wavelength and in units of 
+                the number of frequency channels, and 3 denotes U, V and W
+                components. This is uvw_lambda / wavelength and in units of
                 number of wavelengths
 
-    blc         [numpy array] 3-element numpy array specifying bottom left 
-                corner of the grid coincident with bottom left interferometer 
+    blc         [numpy array] 3-element numpy array specifying bottom left
+                corner of the grid coincident with bottom left interferometer
                 location in UVW coordinate system (same units as uvw)
 
-    trc         [numpy array] 3-element numpy array specifying top right 
-                corner of the grid coincident with top right interferometer 
+    trc         [numpy array] 3-element numpy array specifying top right
+                corner of the grid coincident with top right interferometer
                 location in UVW coordinate system (same units as uvw)
 
-    grid_blc    [numpy array] 3-element numpy array specifying bottom left 
-                corner of the grid in UVW coordinate system including any 
+    grid_blc    [numpy array] 3-element numpy array specifying bottom left
+                corner of the grid in UVW coordinate system including any
                 padding used (same units as uvw)
 
-    grid_trc    [numpy array] 2-element numpy array specifying top right 
-                corner of the grid in UVW coordinate system including any 
+    grid_trc    [numpy array] 2-element numpy array specifying top right
+                corner of the grid in UVW coordinate system including any
                 padding used (same units as uvw)
 
     gridu       [numpy array] 3-dimensional numpy meshgrid array specifying
-                grid u-locations in units of uvw in the UVW coordinate system 
+                grid u-locations in units of uvw in the UVW coordinate system
                 whose corners are specified by attributes grid_blc and grid_trc
 
     gridv       [numpy array] 3-dimensional numpy meshgrid array specifying
-                grid v-locations in units of uvw in the UVW coordinate system 
+                grid v-locations in units of uvw in the UVW coordinate system
                 whose corners are specified by attributes grid_blc and grid_trc
 
     gridw       [numpy array] 3-dimensional numpy meshgrid array specifying
-                grid w-locations in units of uvw in the UVW coordinate system 
+                grid w-locations in units of uvw in the UVW coordinate system
                 whose corners are specified by attributes grid_blc and grid_trc
 
     grid_ready  [boolean] set to True if the gridding has been performed,
-                False if grid is not available yet. Set to False in case 
+                False if grid is not available yet. Set to False in case
                 blc, trc, grid_blc or grid_trc is updated indicating gridding
                 is to be perfomed again
 
@@ -6905,45 +6905,45 @@ class ApertureSynthesis(object):
     n_acc       [scalar] Number of accumulations
 
     pointing_center
-                [2-column numpy array] Pointing center (latitude and 
-                longitude) of the observation at a given timestamp. This is 
-                where the telescopes will be phased up to as reference. 
-                Coordinate system for the pointing_center is specified by another 
+                [2-column numpy array] Pointing center (latitude and
+                longitude) of the observation at a given timestamp. This is
+                where the telescopes will be phased up to as reference.
+                Coordinate system for the pointing_center is specified by another
                 attribute pointing_coords.
 
     phase_center
-                [2-column numpy array] Phase center (latitude and 
-                longitude) of the observation at a given timestamp. This is 
-                where the telescopes will be phased up to as reference. 
-                Coordinate system for the phase_center is specified by another 
+                [2-column numpy array] Phase center (latitude and
+                longitude) of the observation at a given timestamp. This is
+                where the telescopes will be phased up to as reference.
+                Coordinate system for the phase_center is specified by another
                 attribute phase_center_coords.
 
     pointing_coords
-                [string] Coordinate system for telescope pointing. Accepted 
-                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz' 
+                [string] Coordinate system for telescope pointing. Accepted
+                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz'
                 (Altitude-Azimuth). Default = 'hadec'.
 
     phase_center_coords
-                [string] Coordinate system for array phase center. Accepted 
-                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz' 
+                [string] Coordinate system for array phase center. Accepted
+                values are 'radec' (RA-Dec), 'hadec' (HA-Dec) or 'altaz'
                 (Altitude-Azimuth). Default = 'hadec'.
 
     timestamp   [list] List of timestamps during the observation
 
     Member functions:
 
-    __init__()      Initialize an instance of class ApertureSynthesis which 
-                    manages information on a aperture synthesis with an 
+    __init__()      Initialize an instance of class ApertureSynthesis which
+                    manages information on a aperture synthesis with an
                     interferometer array.
 
-    genUVW()        Generate U, V, W (in units of number of wavelengths) by 
-                    phasing the baseline vectors to the phase centers of each 
+    genUVW()        Generate U, V, W (in units of number of wavelengths) by
+                    phasing the baseline vectors to the phase centers of each
                     pointing at all frequencies
 
-    reorderUVW()    Reorder U, V, W (in units of number of wavelengths) of shape 
+    reorderUVW()    Reorder U, V, W (in units of number of wavelengths) of shape
                     nbl x 3 x nchan x n_acc to 3 x (nbl x nchan x n_acc)
 
-    setUVWgrid()    Set up U, V, W grid (in units of number of wavelengths) 
+    setUVWgrid()    Set up U, V, W grid (in units of number of wavelengths)
                     based on the synthesized U, V, W
     ----------------------------------------------------------------------------
     """
@@ -6952,7 +6952,7 @@ class ApertureSynthesis(object):
 
         """
         ------------------------------------------------------------------------
-        Intialize the ApertureSynthesis class which manages information on a 
+        Intialize the ApertureSynthesis class which manages information on a
         aperture synthesis with an interferometer array.
 
         Class attributes initialized are:
@@ -6966,9 +6966,9 @@ class ApertureSynthesis(object):
 
         Keyword input(s):
 
-        interferometer_array    
+        interferometer_array
                      [instance of class InterferometerArray] Instance of class
-                     InterferometerArray used to initialize an instance of 
+                     InterferometerArray used to initialize an instance of
                      class ApertureSynthesis
         ------------------------------------------------------------------------
         """
@@ -7008,8 +7008,8 @@ class ApertureSynthesis(object):
 
         """
         ------------------------------------------------------------------------
-        Generate U, V, W (in units of number of wavelengths) by phasing the 
-        baseline vectors to the phase centers of each pointing at all 
+        Generate U, V, W (in units of number of wavelengths) by phasing the
+        baseline vectors to the phase centers of each pointing at all
         frequencies
         ------------------------------------------------------------------------
         """
@@ -7033,14 +7033,14 @@ class ApertureSynthesis(object):
         self.uvw_lambda = NP.tensordot(self.blxyz, rotmat, axes=[1,1])
         wl = FCNST.c / self.f
         self.uvw = self.uvw_lambda[:,:,NP.newaxis,:] / wl.reshape(1,1,-1,1)
-        
+
     #############################################################################
 
     def reorderUVW(self):
 
         """
         ------------------------------------------------------------------------
-        Reorder U, V, W (in units of number of wavelengths) of shape 
+        Reorder U, V, W (in units of number of wavelengths) of shape
         nbl x 3 x nchan x n_acc to 3 x (nbl x nchan x n_acc)
         ------------------------------------------------------------------------
         """
@@ -7050,34 +7050,34 @@ class ApertureSynthesis(object):
         return reorderedUVW
 
     #############################################################################
-    
+
     def setUVWgrid(self, spacing=0.5, pad=None, pow2=True):
-        
+
         """
         ------------------------------------------------------------------------
-        Routine to produce a grid based on the UVW spacings of the 
-        interferometer array 
+        Routine to produce a grid based on the UVW spacings of the
+        interferometer array
 
         Inputs:
 
-        spacing     [Scalar] Positive value indicating the upper limit on grid 
-                    spacing in uvw-coordinates desirable at the lowest 
+        spacing     [Scalar] Positive value indicating the upper limit on grid
+                    spacing in uvw-coordinates desirable at the lowest
                     wavelength (max frequency). Default = 0.5
 
-        pad         [List] Padding to be applied around the locations 
-                    before forming a grid. List elements should be positive. If 
-                    it is a one-element list, the element is applicable to all 
-                    x, y and z axes. If list contains four or more elements, 
-                    only the first three elements are considered one for each 
+        pad         [List] Padding to be applied around the locations
+                    before forming a grid. List elements should be positive. If
+                    it is a one-element list, the element is applicable to all
+                    x, y and z axes. If list contains four or more elements,
+                    only the first three elements are considered one for each
                     axis. Default = None (no padding).
 
-        pow2        [Boolean] If set to True, the grid is forced to have a size 
-                    a next power of 2 relative to the actual size required. If 
-                    False, gridding is done with the appropriate size as 
+        pow2        [Boolean] If set to True, the grid is forced to have a size
+                    a next power of 2 relative to the actual size required. If
+                    False, gridding is done with the appropriate size as
                     determined by spacing. Default = True.
         ------------------------------------------------------------------------
         """
-        
+
         if self.uvw is None:
             self.genUVW()
 
@@ -7087,7 +7087,7 @@ class ApertureSynthesis(object):
 
         self.trc = NP.amax(NP.abs(NP.vstack((blc, trc))), axis=0)
         self.blc = -1 * self.trc
-        
+
         self.gridu, self.gridv, self.gridw = GRD.grid_3d([(self.blc[0], self.trc[0]), (self.blc[1], self.trc[1]), (self.blc[2], self.trc[2])], pad=pad, spacing=spacing, pow2=True)
 
         self.grid_blc = NP.asarray([self.gridu.min(), self.gridv.min(), self.gridw.min()])
@@ -7100,12 +7100,12 @@ class InterferometerData(object):
 
     """
     ----------------------------------------------------------------------------
-    Class to act as an interface between PRISim object and external data 
-    formats. 
+    Class to act as an interface between PRISim object and external data
+    formats.
 
     Attributes:
 
-    infodict    [dictionary] Dictionary consisting of many attributes loaded 
+    infodict    [dictionary] Dictionary consisting of many attributes loaded
                 from the PRISim object. This will be used to convert to info
                 required in external data formats
 
@@ -7116,7 +7116,7 @@ class InterferometerData(object):
     createUVData()
                 Create an instance of class UVData
 
-    write()     Write an instance of class InterferometerData into specified 
+    write()     Write an instance of class InterferometerData into specified
                 formats. Currently writes in UVFITS format
     ----------------------------------------------------------------------------
     """
@@ -7132,29 +7132,29 @@ class InterferometerData(object):
 
         Inputs:
 
-        prisim_object   
-                    [instance of class InterferometerArray] Instance of 
-                    class InterferometerArray used to initialize an 
+        prisim_object
+                    [instance of class InterferometerArray] Instance of
+                    class InterferometerArray used to initialize an
                     instance of class InterferometerData.
 
-        ref_point   [dictionary] Contains information about the reference 
-                    position to which projected baselines and rotated 
+        ref_point   [dictionary] Contains information about the reference
+                    position to which projected baselines and rotated
                     visibilities are to be computed. Default=None (no additional
-                    phasing will be performed). It must be contain the following 
+                    phasing will be performed). It must be contain the following
                     keys with the following values:
                     'coords'    [string] Refers to the coordinate system in
-                                which value in key 'location' is specified in. 
+                                which value in key 'location' is specified in.
                                 Accepted values are 'radec', 'hadec', 'altaz'
                                 and 'dircos'
-                    'location'  [numpy array] Must be a Mx2 (if value in key 
+                    'location'  [numpy array] Must be a Mx2 (if value in key
                                 'coords' is set to 'radec', 'hadec', 'altaz' or
-                                'dircos') or Mx3 (if value in key 'coords' is 
+                                'dircos') or Mx3 (if value in key 'coords' is
                                 set to 'dircos'). M can be 1 or equal to number
                                 of timestamps. If M=1, the same reference point
-                                in the same coordinate system will be repeated 
+                                in the same coordinate system will be repeated
                                 for all tiemstamps. If value under key 'coords'
-                                is set to 'radec', 'hadec' or 'altaz', the 
-                                value under this key 'location' must be in 
+                                is set to 'radec', 'hadec' or 'altaz', the
+                                value under this key 'location' must be in
                                 units of degrees.
         ------------------------------------------------------------------------
         """
@@ -7200,7 +7200,7 @@ class InterferometerData(object):
         self.infodict['time_array'] = time_array.ravel()
         lst_array = NP.radians(NP.asarray(prisim_object.lst).reshape(-1,1)) + NP.zeros(self.infodict['Nbls']).reshape(1,-1)
         self.infodict['lst_array'] = lst_array.ravel()
-        
+
         labels_A1 = prisim_object.labels['A1']
         labels_A2 = prisim_object.labels['A2']
         if prisim_object.layout:
@@ -7282,7 +7282,7 @@ class InterferometerData(object):
         phase_centers = SkyCoord(ra=phase_center_radec[:,0], dec=phase_center_radec[:,1], frame='icrs', unit='deg')
         pointing_center_obscenter = pointing_centers[int(prisim_object.n_acc/2)]
         phase_center_obscenter = phase_centers[int(prisim_object.n_acc/2)]
-        
+
         self.infodict['object_name'] = 'J{0}{1}'.format(pointing_center_obscenter.ra.to_string(sep='', precision=2, pad=True), pointing_center_obscenter.dec.to_string(sep='', precision=2, alwayssign=True, pad=True))
         if 'id' not in prisim_object.telescope:
             self.infodict['telescope_name'] = 'custom'
@@ -7313,7 +7313,7 @@ class InterferometerData(object):
                 self.infodict['antenna_numbers'] = NP.asarray(list(set(prisim_object.labels['A1']) | set(prisim_object.labels['A2']))).astype(NP.int)
             except ValueError:
                 raise ValueError('Count not convert antenna labels to numbers')
-        
+
         # ----- Optional information ------
         self.infodict['dateobs'] = Time(prisim_object.timestamp[0], format='jd', scale='utc').iso
         self.infodict['phase_center_ra'] = NP.radians(phase_center_obscenter.ra.value)
@@ -7328,13 +7328,13 @@ class InterferometerData(object):
                         warnings.warn('Number of antennas in prisim_object found to be incompatible with number of unique antennas found. Proceeding with default values.')
                     else:
                         self.infodict['antenna_positions'] = prisim_object.layout['positions']
-            
+
         self.infodict['gst0'] = 0.0
         self.infodict['rdate'] = ''
         self.infodict['earth_omega'] = 360.985
         self.infodict['dut1'] = 0.0
         self.infodict['timesys'] = 'UTC'
-        
+
     #############################################################################
 
     def createUVData(self, datatype='noiseless'):
@@ -7345,7 +7345,7 @@ class InterferometerData(object):
 
         Inputs:
 
-        datatype    [string] Specifies which visibilities are to be used in 
+        datatype    [string] Specifies which visibilities are to be used in
                     creating the UVData object. Accepted values are 'noiseless'
                     (default) for noiseless pure-sky visibilities, 'noisy' for
                     sky visibilities to which noise has been added, or 'noise'
@@ -7383,7 +7383,7 @@ class InterferometerData(object):
         return dataobj
 
     #############################################################################
-    
+
     def _blnum_to_antnums(self, blnum):
         if self.infodict['Nants_telescope'] > 2048:
             raise StandardError('error Nants={Nants}>2048 not supported'.format(Nants=self.infodict['Nants_telescope']))
@@ -7396,7 +7396,7 @@ class InterferometerData(object):
         return NP.int32(i), NP.int32(j)
 
     #############################################################################
-    
+
     def _antnums_to_blnum(self, i, j, attempt256=False):
         # set the attempt256 keyword to True to (try to) use the older
         # 256 standard used in many uvfits files
@@ -7419,7 +7419,7 @@ class InterferometerData(object):
         return NP.int64(2048 * (j + 1) + (i + 1) + 2**16)
 
     #############################################################################
-    
+
     def write(self, outfile, datatype='noiseless', fmt='UVFITS',
               uvfits_method=None, overwrite=False):
 
@@ -7432,7 +7432,7 @@ class InterferometerData(object):
 
         outfile     [string] Filename into which data will be written
 
-        datatype    [string] Specifies which visibilities are to be used in 
+        datatype    [string] Specifies which visibilities are to be used in
                     creating the UVData object. Accepted values are 'noiseless'
                     (default) for noiseless pure-sky visibilities, 'noisy' for
                     sky visibilities to which noise has been added, or 'noise'
@@ -7450,8 +7450,8 @@ class InterferometerData(object):
                     but if it fails then the in-house UVFITS writer will be
                     tried.
 
-        overwrite   [boolean] True indicates overwrite even if a file already 
-                    exists. Default = False (does not overwrite). Beware this 
+        overwrite   [boolean] True indicates overwrite even if a file already
+                    exists. Default = False (does not overwrite). Beware this
                     may not work reliably if uvfits_method is set to None or
                     'uvdata' and hence always better to make sure the output
                     file does not exist already
@@ -7493,21 +7493,21 @@ class InterferometerData(object):
                     return
 
             # Try with in-house UVFITS writer
-            try: 
+            try:
                 weights_array = self.infodict['nsample_array'] * NP.where(self.infodict['flag_array'], -1, 1)
                 data_array = self.infodict['data_array'][datatype][:, NP.newaxis, NP.newaxis, :, :, :, NP.newaxis]
                 weights_array = weights_array[:, NP.newaxis, NP.newaxis, :, :, :, NP.newaxis]
                 # uvfits_array_data shape will be  (Nblts,1,1,[Nspws],Nfreqs,Npols,3)
                 uvfits_array_data = NP.concatenate([data_array.real, data_array.imag, weights_array], axis=6)
-        
+
                 uvw_array_sec = self.infodict['uvw_array'] / FCNST.c
                 # jd_midnight = NP.floor(self.infodict['time_array'][0] - 0.5) + 0.5
                 tzero = NP.float32(self.infodict['time_array'][0])
-            
+
                 # uvfits convention is that time_array + relevant PZERO = actual JD
                 # We are setting PZERO4 = float32(first time of observation)
                 time_array = NP.float32(self.infodict['time_array'] - NP.float64(tzero))
-        
+
                 int_time_array = (NP.zeros_like((time_array), dtype=NP.float) + self.infodict['integration_time'])
                 baselines_use = self._antnums_to_blnum(self.infodict['ant_1_array'], self.infodict['ant_2_array'], attempt256=True)
                 # Set up dictionaries for populating hdu
@@ -7548,21 +7548,21 @@ class InterferometerData(object):
                 hdu = fits.GroupData(uvfits_array_data, parnames=parnames_use,
                                      pardata=group_parameter_list, bitpix=-32)
                 hdu = fits.GroupsHDU(hdu)
-        
+
                 for i, key in enumerate(parnames_use):
                     hdu.header['PSCAL' + str(i + 1) + '  '] = pscal_dict[key]
                     hdu.header['PZERO' + str(i + 1) + '  '] = pzero_dict[key]
-        
+
                 # ISO string of first time in self.infodict['time_array']
 
                 # hdu.header['DATE-OBS'] = Time(self.infodict['time_array'][0], scale='utc', format='jd').iso
                 hdu.header['DATE-OBS'] = self.infodict['dateobs']
-        
+
                 hdu.header['CTYPE2  '] = 'COMPLEX '
                 hdu.header['CRVAL2  '] = 1.0
                 hdu.header['CRPIX2  '] = 1.0
                 hdu.header['CDELT2  '] = 1.0
-        
+
                 hdu.header['CTYPE3  '] = 'STOKES  '
                 hdu.header['CRVAL3  '] = self.infodict['polarization_array'][0]
                 hdu.header['CRPIX3  '] = 1.0
@@ -7570,27 +7570,27 @@ class InterferometerData(object):
                     hdu.header['CDELT3  '] = NP.diff(self.infodict['polarization_array'])[0]
                 except(IndexError):
                     hdu.header['CDELT3  '] = 1.0
-        
+
                 hdu.header['CTYPE4  '] = 'FREQ    '
                 hdu.header['CRVAL4  '] = self.infodict['freq_array'][0, 0]
                 hdu.header['CRPIX4  '] = 1.0
                 hdu.header['CDELT4  '] = NP.diff(self.infodict['freq_array'][0])[0]
-        
+
                 hdu.header['CTYPE5  '] = 'IF      '
                 hdu.header['CRVAL5  '] = 1.0
                 hdu.header['CRPIX5  '] = 1.0
                 hdu.header['CDELT5  '] = 1.0
-        
+
                 hdu.header['CTYPE6  '] = 'RA'
                 hdu.header['CRVAL6  '] = NP.degrees(self.infodict['phase_center_ra'])
-        
+
                 hdu.header['CTYPE7  '] = 'DEC'
                 hdu.header['CRVAL7  '] = NP.degrees(self.infodict['phase_center_dec'])
-        
+
                 hdu.header['BUNIT   '] = self.infodict['vis_units']
                 hdu.header['BSCALE  '] = 1.0
                 hdu.header['BZERO   '] = 0.0
-        
+
                 hdu.header['OBJECT  '] = self.infodict['object_name']
                 hdu.header['TELESCOP'] = self.infodict['telescope_name']
                 hdu.header['LAT     '] = self.infodict['telescope_location'][0]
@@ -7598,22 +7598,22 @@ class InterferometerData(object):
                 hdu.header['ALT     '] = self.infodict['telescope_location'][2]
                 hdu.header['INSTRUME'] = self.infodict['instrument']
                 hdu.header['EPOCH   '] = float(self.infodict['phase_center_epoch'])
-        
+
                 for line in self.infodict['history'].splitlines():
                     hdu.header.add_history(line)
-            
+
                 # ADD the ANTENNA table
                 staxof = NP.zeros(self.infodict['Nants_telescope'])
-        
+
                 # 0 specifies alt-az, 6 would specify a phased array
                 mntsta = NP.zeros(self.infodict['Nants_telescope'])
-        
+
                 # beware, X can mean just about anything
                 poltya = NP.full((self.infodict['Nants_telescope']), 'X', dtype=NP.object_)
                 polaa = [90.0] + NP.zeros(self.infodict['Nants_telescope'])
                 poltyb = NP.full((self.infodict['Nants_telescope']), 'Y', dtype=NP.object_)
                 polab = [0.0] + NP.zeros(self.infodict['Nants_telescope'])
-        
+
                 col1 = fits.Column(name='ANNAME', format='8A',
                                    array=self.infodict['antenna_names'])
                 col2 = fits.Column(name='STABXYZ', format='3D',
@@ -7630,7 +7630,7 @@ class InterferometerData(object):
                 col10 = fits.Column(name='POLAB', format='1E', array=polab)
                 # col11 = fits.Column(name='POLCALB', format='3E', array=polcalb)
                 # note ORBPARM is technically required, but we didn't put it in
-        
+
                 cols = fits.ColDefs([col1, col2, col3, col4, col5, col6, col7, col9, col10])
                 ant_hdu = fits.BinTableHDU.from_columns(cols)
                 ant_hdu.header['EXTNAME'] = 'AIPS AN'
@@ -7646,7 +7646,7 @@ class InterferometerData(object):
                 ant_hdu.header['FREQ'] = self.infodict['freq_array'][0, 0]
                 ant_hdu.header['RDATE'] = self.infodict['rdate']
                 ant_hdu.header['UT1UTC'] = self.infodict['dut1']
-        
+
                 ant_hdu.header['TIMSYS'] = self.infodict['timesys']
                 if self.infodict['timesys'] == 'IAT':
                     warnings.warn('This file has an "IAT" time system. Files of '
@@ -7655,32 +7655,32 @@ class InterferometerData(object):
                 ant_hdu.header['NO_IF'] = self.infodict['Nspws']
                 ant_hdu.header['DEGPDY'] = self.infodict['earth_omega']
                 # ant_hdu.header['IATUTC'] = 35.
-        
+
                 # set mandatory parameters which are not supported by this object
                 # (or that we just don't understand)
                 ant_hdu.header['NUMORB'] = 0
-        
+
                 # note: Bart had this set to 3. We've set it 0 after aips 117. -jph
                 ant_hdu.header['NOPCAL'] = 0
-        
+
                 ant_hdu.header['POLTYPE'] = 'X-Y LIN'
-        
+
                 # note: we do not support the concept of "frequency setups"
                 # -- lists of spws given in a SU table.
                 ant_hdu.header['FREQID'] = -1
-        
+
                 # if there are offsets in images, this could be the culprit
                 ant_hdu.header['POLARX'] = 0.0
                 ant_hdu.header['POLARY'] = 0.0
-        
+
                 ant_hdu.header['DATUTC'] = 0  # ONLY UTC SUPPORTED
-        
+
                 # we always output right handed coordinates
                 ant_hdu.header['XYZHAND'] = 'RIGHT'
-        
+
                 # ADD the FQ table
                 # skipping for now and limiting to a single spw
-        
+
                 # write the file
                 hdulist = fits.HDUList(hdus=[hdu, ant_hdu])
                 hdulist.writeto(outfile, clobber=overwrite)
@@ -7693,4 +7693,3 @@ class InterferometerData(object):
                 return
 
 #################################################################################
-    


### PR DESCRIPTION
I made a few changes to the use of pyuvdata module inside of prisim that allows the pyuvdata module to write the uvfits output format.

There are a lot of diff lines were single spaces get deleted though. I don't remember making those but it does not appear to delete any content or create conflicts.

Most noticeably prisim now uses the pyuvdata.utils.XYZ_from_LatLonAlt to calculate the XYZ in ITRF frame coordinates if uvfits_method = 'uvdata' and sets the telescope_location array in the uvdataobj to XYZ.

also sets the phase_type parameter in the uvdataobj, not previously set when using the uvdata method.